### PR TITLE
discourage use of application context

### DIFF
--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
@@ -16,12 +16,14 @@
 
 package com.mtramin.rxfingerprint;
 
+import android.app.Application;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 import android.support.v4.hardware.fingerprint.FingerprintManagerCompat.AuthenticationCallback;
 import android.support.v4.os.CancellationSignal;
+import android.util.Log;
 
 import com.mtramin.rxfingerprint.data.FingerprintAuthenticationException;
 
@@ -45,7 +47,14 @@ abstract class FingerprintObservable<T> implements Action1<AsyncEmitter<T>> {
      * @param context Context to be used for the fingerprint authentication
      */
     FingerprintObservable(Context context) {
-        this.context = context.getApplicationContext();
+        // If this is an Application Context, it causes issues when rotating the device while
+        // the sensor is active. The 2nd callback will receive the cancellation error of the first
+        // authentication action which will immediately onError and unsubscribe the 2nd
+        // authentication action.
+        if (context instanceof Application) {
+            Log.w("RxFingerprint", "Passing an Application Context to RxFingerprint might cause issues when the authentication is active and the application changes orientation. Consider passing an Activity Context.");
+        }
+        this.context = context;
     }
 
     @Override

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -43,8 +43,8 @@ android {
 
 
 dependencies {
-//    compile project(':rxfingerprint');
-    compile "com.mtramin:rxfingerprint:$versions.name"
+    compile project(':rxfingerprint');
+//    compile "com.mtramin:rxfingerprint:$versions.name"
 
     compile "com.android.support:appcompat-v7:$versions.supportLibrary"
 }


### PR DESCRIPTION
This will fix #8.

As described in the javadoc, the issue is that when using an application context for calling the FingerprintManager, the cancellation of the first operation will call the callback of the second operation. This will call onError on the emitter which will unsubscribe the authentication Observable, resulting in a cancelled authentication operation when the application changes orientation.