### PR TITLE
remove usage of experimental rxjava emitter

### DIFF
--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintAuthenticationObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintAuthenticationObservable.java
@@ -23,51 +23,49 @@ import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 import com.mtramin.rxfingerprint.data.FingerprintAuthenticationResult;
 import com.mtramin.rxfingerprint.data.FingerprintResult;
 
-import rx.Emitter;
 import rx.Observable;
-
-import static rx.Emitter.BackpressureMode.LATEST;
+import rx.Subscriber;
 
 /**
  * Authenticates the user with his fingerprint.
  */
 class FingerprintAuthenticationObservable extends FingerprintObservable<FingerprintAuthenticationResult> {
 
-    private FingerprintAuthenticationObservable(Context context) {
-        super(context);
-    }
+	/**
+	 * Creates an Observable that will enable the fingerprint scanner of the device and listen for
+	 * the users fingerprint for authentication
+	 *
+	 * @param context context to use
+	 * @return Observable {@link FingerprintAuthenticationResult}
+	 */
+	static Observable<FingerprintAuthenticationResult> create(Context context) {
+		return Observable.create(new FingerprintAuthenticationObservable(context));
+	}
 
-    /**
-     * Creates an Observable that will enable the fingerprint scanner of the device and listen for
-     * the users fingerprint for authentication
-     *
-     * @param context context to use
-     * @return Observable {@link FingerprintAuthenticationResult}
-     */
-    static Observable<FingerprintAuthenticationResult> create(Context context) {
-        return Observable.fromEmitter(new FingerprintAuthenticationObservable(context), LATEST);
-    }
+	private FingerprintAuthenticationObservable(Context context) {
+		super(context);
+	}
 
-    @Nullable
-    @Override
-    protected FingerprintManagerCompat.CryptoObject initCryptoObject(Emitter<FingerprintAuthenticationResult> subscriber) {
-        // Simple authentication does not need CryptoObject
-        return null;
-    }
+	@Nullable
+	@Override
+	protected FingerprintManagerCompat.CryptoObject initCryptoObject(Subscriber<FingerprintAuthenticationResult> subscriber) {
+		// Simple authentication does not need CryptoObject
+		return null;
+	}
 
-    @Override
-    protected void onAuthenticationSucceeded(Emitter<FingerprintAuthenticationResult> emitter, FingerprintManagerCompat.AuthenticationResult result) {
-        emitter.onNext(new FingerprintAuthenticationResult(FingerprintResult.AUTHENTICATED, null));
-        emitter.onCompleted();
-    }
+	@Override
+	protected void onAuthenticationSucceeded(Subscriber<FingerprintAuthenticationResult> subscriber, FingerprintManagerCompat.AuthenticationResult result) {
+		subscriber.onNext(new FingerprintAuthenticationResult(FingerprintResult.AUTHENTICATED, null));
+		subscriber.onCompleted();
+	}
 
-    @Override
-    protected void onAuthenticationHelp(Emitter<FingerprintAuthenticationResult> emitter, int helpMessageId, String helpString) {
-        emitter.onNext(new FingerprintAuthenticationResult(FingerprintResult.HELP, helpString));
-    }
+	@Override
+	protected void onAuthenticationHelp(Subscriber<FingerprintAuthenticationResult> subscriber, int helpMessageId, String helpString) {
+		subscriber.onNext(new FingerprintAuthenticationResult(FingerprintResult.HELP, helpString));
+	}
 
-    @Override
-    protected void onAuthenticationFailed(Emitter<FingerprintAuthenticationResult> emitter) {
-        emitter.onNext(new FingerprintAuthenticationResult(FingerprintResult.FAILED, null));
-    }
+	@Override
+	protected void onAuthenticationFailed(Subscriber<FingerprintAuthenticationResult> subscriber) {
+		subscriber.onNext(new FingerprintAuthenticationResult(FingerprintResult.FAILED, null));
+	}
 }

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintEncryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintEncryptionObservable.java
@@ -40,10 +40,8 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.IvParameterSpec;
 
-import rx.Emitter;
 import rx.Observable;
-
-import static rx.Emitter.BackpressureMode.LATEST;
+import rx.Subscriber;
 
 /**
  * Encrypts data with fingerprint authentication. Initializes a {@link Cipher} for encryption which
@@ -52,79 +50,79 @@ import static rx.Emitter.BackpressureMode.LATEST;
  */
 class FingerprintEncryptionObservable extends FingerprintObservable<FingerprintEncryptionResult> {
 
-    private final String keyName;
-    private final String toEncrypt;
+	private final String keyName;
+	private final String toEncrypt;
 
-    private FingerprintEncryptionObservable(Context context, String keyName, String toEncrypt) {
-        super(context);
-        this.keyName = keyName;
+	/**
+	 * Creates a new FingerprintEncryptionObservable that will listen to fingerprint authentication
+	 * to encrypt the given data.
+	 *
+	 * @param context   context to use
+	 * @param keyName   name of the key in the keystore
+	 * @param toEncrypt data to encrypt  @return Observable {@link FingerprintEncryptionResult}
+	 */
+	static Observable<FingerprintEncryptionResult> create(Context context, String keyName, String toEncrypt) {
+		return Observable.create(new FingerprintEncryptionObservable(context, keyName, toEncrypt));
+	}
 
-        if (toEncrypt == null) {
-            throw new NullPointerException("String to be encrypted is null. Can only encrypt valid strings");
-        }
-        this.toEncrypt = toEncrypt;
-    }
+	/**
+	 * Creates a new FingerprintEncryptionObservable that will listen to fingerprint authentication
+	 * to encrypt the given data.
+	 *
+	 * @param context   context to use
+	 * @param toEncrypt data to encrypt  @return Observable {@link FingerprintEncryptionResult}
+	 */
+	static Observable<FingerprintEncryptionResult> create(Context context, String toEncrypt) {
+		return Observable.create(new FingerprintEncryptionObservable(context, null, toEncrypt));
+	}
 
-    /**
-     * Creates a new FingerprintEncryptionObservable that will listen to fingerprint authentication
-     * to encrypt the given data.
-     *
-     * @param context   context to use
-     * @param keyName   name of the key in the keystore
-     * @param toEncrypt data to encrypt  @return Observable {@link FingerprintEncryptionResult}
-     */
-    static Observable<FingerprintEncryptionResult> create(Context context, String keyName, String toEncrypt) {
-        return Observable.fromEmitter(new FingerprintEncryptionObservable(context, keyName, toEncrypt), LATEST);
-    }
+	private FingerprintEncryptionObservable(Context context, String keyName, String toEncrypt) {
+		super(context);
+		this.keyName = keyName;
 
-    /**
-     * Creates a new FingerprintEncryptionObservable that will listen to fingerprint authentication
-     * to encrypt the given data.
-     *
-     * @param context   context to use
-     * @param toEncrypt data to encrypt  @return Observable {@link FingerprintEncryptionResult}
-     */
-    static Observable<FingerprintEncryptionResult> create(Context context, String toEncrypt) {
-        return Observable.fromEmitter(new FingerprintEncryptionObservable(context, null, toEncrypt), LATEST);
-    }
+		if (toEncrypt == null) {
+			throw new NullPointerException("String to be encrypted is null. Can only encrypt valid strings");
+		}
+		this.toEncrypt = toEncrypt;
+	}
 
-    @Nullable
-    @Override
-    protected FingerprintManagerCompat.CryptoObject initCryptoObject(Emitter<FingerprintEncryptionResult> emitter) {
-        CryptoProvider cryptoProvider = new CryptoProvider(this.context, this.keyName);
-        try {
-            Cipher cipher = cryptoProvider.initEncryptionCipher();
-            return new FingerprintManagerCompat.CryptoObject(cipher);
-        } catch (InvalidKeyException | NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException | InvalidAlgorithmParameterException | CertificateException | UnrecoverableKeyException | KeyStoreException | IOException e) {
-            emitter.onError(e);
-            return null;
-        }
+	@Nullable
+	@Override
+	protected FingerprintManagerCompat.CryptoObject initCryptoObject(Subscriber<FingerprintEncryptionResult> subscriber) {
+		CryptoProvider cryptoProvider = new CryptoProvider(context, keyName);
+		try {
+			Cipher cipher = cryptoProvider.initEncryptionCipher();
+			return new FingerprintManagerCompat.CryptoObject(cipher);
+		} catch (InvalidKeyException | NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException | InvalidAlgorithmParameterException | CertificateException | UnrecoverableKeyException | KeyStoreException | IOException e) {
+			subscriber.onError(e);
+			return null;
+		}
 
-    }
+	}
 
-    @Override
-    protected void onAuthenticationSucceeded(Emitter<FingerprintEncryptionResult> emitter, FingerprintManagerCompat.AuthenticationResult result) {
-        try {
-            Cipher cipher = result.getCryptoObject().getCipher();
-            byte[] encryptedBytes = cipher.doFinal(toEncrypt.getBytes("UTF-8"));
-            byte[] ivBytes = cipher.getParameters().getParameterSpec(IvParameterSpec.class).getIV();
+	@Override
+	protected void onAuthenticationSucceeded(Subscriber<FingerprintEncryptionResult> subscriber, FingerprintManagerCompat.AuthenticationResult result) {
+		try {
+			Cipher cipher = result.getCryptoObject().getCipher();
+			byte[] encryptedBytes = cipher.doFinal(toEncrypt.getBytes("UTF-8"));
+			byte[] ivBytes = cipher.getParameters().getParameterSpec(IvParameterSpec.class).getIV();
 
-            CryptoData cryptoData = CryptoData.fromBytes(encryptedBytes, ivBytes);
+			CryptoData cryptoData = CryptoData.fromBytes(encryptedBytes, ivBytes);
 
-            emitter.onNext(new FingerprintEncryptionResult(FingerprintResult.AUTHENTICATED, null, cryptoData.toString()));
-            emitter.onCompleted();
-        } catch (IllegalBlockSizeException | BadPaddingException | InvalidParameterSpecException | UnsupportedEncodingException e) {
-            emitter.onError(e);
-        }
-    }
+			subscriber.onNext(new FingerprintEncryptionResult(FingerprintResult.AUTHENTICATED, null, cryptoData.toString()));
+			subscriber.onCompleted();
+		} catch (IllegalBlockSizeException | BadPaddingException | InvalidParameterSpecException | UnsupportedEncodingException e) {
+			subscriber.onError(e);
+		}
+	}
 
-    @Override
-    protected void onAuthenticationHelp(Emitter<FingerprintEncryptionResult> emitter, int helpMessageId, String helpString) {
-        emitter.onNext(new FingerprintEncryptionResult(FingerprintResult.HELP, helpString, null));
-    }
+	@Override
+	protected void onAuthenticationHelp(Subscriber<FingerprintEncryptionResult> subscriber, int helpMessageId, String helpString) {
+		subscriber.onNext(new FingerprintEncryptionResult(FingerprintResult.HELP, helpString, null));
+	}
 
-    @Override
-    protected void onAuthenticationFailed(Emitter<FingerprintEncryptionResult> emitter) {
-        emitter.onNext(new FingerprintEncryptionResult(FingerprintResult.FAILED, null, null));
-    }
+	@Override
+	protected void onAuthenticationFailed(Subscriber<FingerprintEncryptionResult> subscriber) {
+		subscriber.onNext(new FingerprintEncryptionResult(FingerprintResult.FAILED, null, null));
+	}
 }

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
@@ -27,48 +27,49 @@ import android.util.Log;
 
 import com.mtramin.rxfingerprint.data.FingerprintAuthenticationException;
 
-import rx.Emitter;
+import rx.Observable;
 import rx.Subscriber;
-import rx.functions.Action1;
 import rx.subscriptions.Subscriptions;
 
 /**
  * Base observable for Fingerprint authentication. Provides abstract methods that allow
  * to alter the input and result of the authentication.
  */
-abstract class FingerprintObservable<T> implements Action1<Emitter<T>> {
+abstract class FingerprintObservable<T> implements Observable.OnSubscribe<T> {
 
 	protected final Context context;
 	private CancellationSignal cancellationSignal;
 
-    /**
-     * Default constructor for fingerprint authentication
-     *
-     * @param context Context to be used for the fingerprint authentication
-     */
-    FingerprintObservable(Context context) {
-        // If this is an Application Context, it causes issues when rotating the device while
-        // the sensor is active. The 2nd callback will receive the cancellation error of the first
-        // authentication action which will immediately onError and unsubscribe the 2nd
-        // authentication action.
-        if (context instanceof Application) {
-            Log.w("RxFingerprint", "Passing an Application Context to RxFingerprint might cause issues when the authentication is active and the application changes orientation. Consider passing an Activity Context.");
-        }
-        this.context = context;
-    }
+	/**
+	 * Default constructor for fingerprint authentication
+	 *
+	 * @param context Context to be used for the fingerprint authentication
+	 */
+	FingerprintObservable(Context context) {
+		// If this is an Application Context, it causes issues when rotating the device while
+		// the sensor is active. The 2nd callback will receive the cancellation error of the first
+		// authentication action which will immediately onError and unsubscribe the 2nd
+		// authentication action.
+		if (context instanceof Application) {
+			Log.w("RxFingerprint", "Passing an Application Context to RxFingerprint might cause issues when the authentication is active and the application changes orientation. Consider passing an Activity Context.");
+		}
+		this.context = context;
+	}
 
 	@Override
-	public void call(Emitter<T> emitter) {
+	public void call(Subscriber subscriber) {
 		if (!RxFingerprint.isAvailable(context)) {
-			emitter.onError(new IllegalAccessException("Fingerprint authentication is not available on this device! Ensure that the device has a Fingerprint sensor and enrolled Fingerprints by calling RxFingerprint#isAvailable(Context) first"));
+			if (!subscriber.isUnsubscribed()) {
+				subscriber.onError(new IllegalAccessException("Fingerprint authentication is not available on this device! Ensure that the device has a Fingerprint sensor and enrolled Fingerprints by calling RxFingerprint#isAvailable(Context) first"));
+			}
 		}
 
-		AuthenticationCallback callback = createAuthenticationCallback(emitter);
+		AuthenticationCallback callback = createAuthenticationCallback(subscriber);
 		cancellationSignal = new CancellationSignal();
-		FingerprintManagerCompat.CryptoObject cryptoObject = initCryptoObject(emitter);
+		FingerprintManagerCompat.CryptoObject cryptoObject = initCryptoObject(subscriber);
 		FingerprintManagerCompat.from(context).authenticate(cryptoObject, 0, cancellationSignal, callback, null);
 
-		emitter.setSubscription(Subscriptions.create(() -> {
+		subscriber.add(Subscriptions.create(() -> {
 			if (cancellationSignal != null && !cancellationSignal.isCanceled()) {
 				cancellationSignal.cancel();
 			}
@@ -77,30 +78,38 @@ abstract class FingerprintObservable<T> implements Action1<Emitter<T>> {
 	}
 
 	@NonNull
-	private AuthenticationCallback createAuthenticationCallback(Emitter<T> emitter) {
+	private AuthenticationCallback createAuthenticationCallback(Subscriber<T> subscriber) {
 		return new AuthenticationCallback() {
 			@Override
 			public void onAuthenticationError(int errMsgId, CharSequence errString) {
 				super.onAuthenticationError(errMsgId, errString);
-				emitter.onError(new FingerprintAuthenticationException(errString));
+				if (!subscriber.isUnsubscribed()) {
+					subscriber.onError(new FingerprintAuthenticationException(errString));
+				}
 			}
 
 			@Override
 			public void onAuthenticationFailed() {
 				super.onAuthenticationFailed();
-				FingerprintObservable.this.onAuthenticationFailed(emitter);
+				if (!subscriber.isUnsubscribed()) {
+					FingerprintObservable.this.onAuthenticationFailed(subscriber);
+				}
 			}
 
 			@Override
 			public void onAuthenticationHelp(int helpMsgId, CharSequence helpString) {
 				super.onAuthenticationHelp(helpMsgId, helpString);
-				FingerprintObservable.this.onAuthenticationHelp(emitter, helpMsgId, helpString.toString());
+				if (!subscriber.isUnsubscribed()) {
+					FingerprintObservable.this.onAuthenticationHelp(subscriber, helpMsgId, helpString.toString());
+				}
 			}
 
 			@Override
 			public void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result) {
 				super.onAuthenticationSucceeded(result);
-				FingerprintObservable.this.onAuthenticationSucceeded(emitter, result);
+				if (!subscriber.isUnsubscribed()) {
+					FingerprintObservable.this.onAuthenticationSucceeded(subscriber, result);
+				}
 			}
 		};
 	}
@@ -109,12 +118,12 @@ abstract class FingerprintObservable<T> implements Action1<Emitter<T>> {
 	 * Method to initialize the {@link FingerprintManagerCompat.CryptoObject}
 	 * used for the fingerprint authentication.
 	 *
-	 * @param emitter current emitter
+	 * @param subscriber current subscriber
 	 * @return a {@link FingerprintManagerCompat.CryptoObject}
 	 * that is to be used in the authentication. May be {@code null}.
 	 */
 	@Nullable
-	protected abstract FingerprintManagerCompat.CryptoObject initCryptoObject(Emitter<T> emitter);
+	protected abstract FingerprintManagerCompat.CryptoObject initCryptoObject(Subscriber<T> subscriber);
 
 	/**
 	 * Action to execute when fingerprint authentication was successful.
@@ -122,10 +131,10 @@ abstract class FingerprintObservable<T> implements Action1<Emitter<T>> {
 	 * <p/>
 	 * Should call {@link Subscriber#onCompleted()}.
 	 *
-	 * @param emitter current emitter
-	 * @param result  result of the successful fingerprint authentication
+	 * @param subscriber current subscriber
+	 * @param result     result of the successful fingerprint authentication
 	 */
-	protected abstract void onAuthenticationSucceeded(Emitter<T> emitter, FingerprintManagerCompat.AuthenticationResult result);
+	protected abstract void onAuthenticationSucceeded(Subscriber<T> subscriber, FingerprintManagerCompat.AuthenticationResult result);
 
 	/**
 	 * Action to execute when the fingerprint authentication returned a help result.
@@ -133,11 +142,11 @@ abstract class FingerprintObservable<T> implements Action1<Emitter<T>> {
 	 * <p/>
 	 * Should <b>not</b> {@link Subscriber#onCompleted()}.
 	 *
-	 * @param emitter       current emitter
+	 * @param subscriber    current subscriber
 	 * @param helpMessageId ID of the help message returned from the {@link FingerprintManagerCompat}
 	 * @param helpString    Help message string returned by the {@link FingerprintManagerCompat}
 	 */
-	protected abstract void onAuthenticationHelp(Emitter<T> emitter, int helpMessageId, String helpString);
+	protected abstract void onAuthenticationHelp(Subscriber<T> subscriber, int helpMessageId, String helpString);
 
 	/**
 	 * Action to execute when the fingerprint authentication failed.
@@ -146,7 +155,7 @@ abstract class FingerprintObservable<T> implements Action1<Emitter<T>> {
 	 * Should only call {@link Subscriber#onCompleted()} when fingerprint authentication should be
 	 * canceled due to the failed event.
 	 *
-	 * @param emitter current emitter
+	 * @param subscriber current subscriber
 	 */
-	protected abstract void onAuthenticationFailed(Emitter<T> emitter);
+	protected abstract void onAuthenticationFailed(Subscriber<T> subscriber);
 }


### PR DESCRIPTION
Since using the `Observable.fromAsync`/`Observable.fromEmitter` method caused issues with newer RxJava versions due to its @Experimental state, revert back to using `Observable.create` to keep clients safe.

/cc @joshafeinberg