### PR TITLE
improve exception messages and verify encryption output

### DIFF
--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/CryptoData.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/CryptoData.java
@@ -23,42 +23,48 @@ import android.util.Base64;
  * Data of a cryptographic operation with RxFingerprint.
  */
 class CryptoData {
-    private static final String SEPARATOR = "-_-";
+	static final String SEPARATOR = "-_-";
 
     private final String messageEncoded;
     private final String ivEncoded;
 
     private CryptoData(byte[] messageBytes, byte[] ivBytes) {
-        this.messageEncoded = encode(messageBytes);
-        this.ivEncoded = encode(ivBytes);
+		messageEncoded = encode(messageBytes);
+		ivEncoded = encode(ivBytes);
     }
 
     private CryptoData(String message, String iv) {
-        this.messageEncoded = message;
-        this.ivEncoded = iv;
+		messageEncoded = message;
+		ivEncoded = iv;
     }
 
     /**
-     * Sets up data from an input string.
-     *
-     * @param input input string that was previously encrypted by RxFingerprint
-     * @return parsed data
-     */
-    static CryptoData fromString(String input) {
-        if (input == null) {
-            throw new NullPointerException("Input for decryption is null. Make sure to provide a valid, encrypted String for decryption.");
-        }
+	 * Sets up data from an input string.
+	 *
+	 * @param input input string that was previously encrypted by RxFingerprint
+	 * @return parsed data
+	 */
+	static CryptoData fromString(String input) throws CryptoDataException {
+		verifyCryptoDataString(input);
 
-        if (input.isEmpty() || !input.contains(SEPARATOR)) {
-            throw new IllegalArgumentException("Invalid input given for decryption operation. Make sure you provide a string that was previously encrypted by RxFingerprint.");
-        }
+		String[] inputParams = input.split(SEPARATOR);
+		return new CryptoData(inputParams[0], inputParams[1]);
+	}
 
-        String[] inputParams = input.split(SEPARATOR);
-        return new CryptoData(inputParams[0], inputParams[1]);
-    }
+	/**
+	 * Checks if the given input is a valid encrypted string. Will throw an exception if the input
+	 * is invalid.
+	 *
+	 * @param input input to verify
+	 */
+	static void verifyCryptoDataString(String input) throws CryptoDataException {
+		if (input.isEmpty() || !input.contains(SEPARATOR)) {
+			throw CryptoDataException.fromCryptoDataString(input);
+		}
+	}
 
-    /**
-     * Sets up data from encrypted byte that resulted from encryption operation.
+	/**
+	 * Sets up data from encrypted byte that resulted from encryption operation.
      *
      * @param messageBytes encrypted bytes of message
      * @param ivBytes      initialization vector in bytes
@@ -70,7 +76,7 @@ class CryptoData {
 
     @Override
     public String toString() {
-        return this.messageEncoded + SEPARATOR + this.ivEncoded;
+        return messageEncoded + SEPARATOR + ivEncoded;
     }
 
     /**
@@ -87,12 +93,12 @@ class CryptoData {
         return decode(messageEncoded);
     }
 
-     byte[] decode(String messageEncoded) {
+     private static byte[] decode(String messageEncoded) {
         return Base64.decode(messageEncoded, Base64.DEFAULT);
     }
 
     @NonNull
-    private String encode(byte[] messageBytes) {
+    private static String encode(byte[] messageBytes) {
         return Base64.encodeToString(messageBytes, Base64.DEFAULT);
     }
 }

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/CryptoDataException.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/CryptoDataException.java
@@ -1,0 +1,21 @@
+package com.mtramin.rxfingerprint;
+
+import static com.mtramin.rxfingerprint.CryptoData.SEPARATOR;
+
+/**
+ * Exception thrown when CryptoData is invalid
+ */
+class CryptoDataException extends Exception {
+
+	private CryptoDataException(String message) {
+		super(message);
+	}
+
+	static CryptoDataException fromCryptoDataString(String input) {
+		boolean isEmpty = input.isEmpty();
+		boolean containsSeparator = input.contains(SEPARATOR);
+		String message = String.format("Invalid input given for decryption operation. Make sure you provide a string that was previously encrypted by RxFingerprint. empty: %s, correct format: %s", isEmpty, containsSeparator);
+
+		return new CryptoDataException(message);
+	}
+}

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintEncryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintEncryptionObservable.java
@@ -107,11 +107,12 @@ class FingerprintEncryptionObservable extends FingerprintObservable<FingerprintE
 			byte[] encryptedBytes = cipher.doFinal(toEncrypt.getBytes("UTF-8"));
 			byte[] ivBytes = cipher.getParameters().getParameterSpec(IvParameterSpec.class).getIV();
 
-			CryptoData cryptoData = CryptoData.fromBytes(encryptedBytes, ivBytes);
+			String encryptedString = CryptoData.fromBytes(encryptedBytes, ivBytes).toString();
+			CryptoData.verifyCryptoDataString(encryptedString);
 
-			subscriber.onNext(new FingerprintEncryptionResult(FingerprintResult.AUTHENTICATED, null, cryptoData.toString()));
+			subscriber.onNext(new FingerprintEncryptionResult(FingerprintResult.AUTHENTICATED, null, encryptedString));
 			subscriber.onCompleted();
-		} catch (IllegalBlockSizeException | BadPaddingException | InvalidParameterSpecException | UnsupportedEncodingException e) {
+		} catch (CryptoDataException | IllegalBlockSizeException | BadPaddingException | InvalidParameterSpecException | UnsupportedEncodingException e) {
 			subscriber.onError(e);
 		}
 	}

--- a/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/CryptoDataTest.java
+++ b/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/CryptoDataTest.java
@@ -1,0 +1,21 @@
+package com.mtramin.rxfingerprint;
+
+import org.junit.Test;
+
+public class CryptoDataTest {
+
+	@Test
+	public void fromStringValid() throws Exception {
+		CryptoData.fromString("abc-_-123");
+	}
+
+	@Test(expected = CryptoDataException.class)
+	public void fromInvalidString() throws Exception {
+		CryptoData.fromString("123");
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void fromNullString() throws Exception {
+		CryptoData.fromString(null);
+	}
+}


### PR DESCRIPTION
#15 

Also added a verification step during encryption to make sure the output will always be a valid string.

All errors because of the inputs will now be emitted as `onError(CryptoDataException)` and not throw a fatal Exception anymore.