### PR TITLE
prevent onError to be emitted when emitter is disposed

### DIFF
--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
@@ -80,7 +80,9 @@ abstract class FingerprintObservable<T> implements ObservableOnSubscribe<T> {
 			@Override
 			public void onAuthenticationError(int errMsgId, CharSequence errString) {
 				super.onAuthenticationError(errMsgId, errString);
-				emitter.onError(new FingerprintAuthenticationException(errString));
+				if (!emitter.isDisposed()) {
+					emitter.onError(new FingerprintAuthenticationException(errString));
+				}
 			}
 
 			@Override


### PR DESCRIPTION
Fixes #20 

This prevents onErrors to be emitted when `FingerprintObservable`s have already been disposed of.
This caused issues when the `FingerprintObservable` was disposed of, since this cancels the Fingerprint operation with a `CancellationSignal` internally. The Android Fingerprint API would then callback with `onAuthenticationError` "Fingerprint operation canceled." which would actually throw because of how RxJava2 works internally.