### PR TITLE
Use FingerprintManager instead of FingerprintManagerCompat

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Should the device not contain a fingerprint sensor or the user has not enrolled 
 After successful authentication or a recoverable error (e.g. the sensor could not read the fingerprint clearly) `onNext` will be called. You can check the result if the authentication was successful.
 In the case of a recoverable error it provides the error message.
 
-By unsubscribing from the Subscription, the fingerprint sensor will be disabled again with no result.
+By disposing the `Disposable`, the fingerprint sensor will be disabled again with no result.
 
 ### Encryption-and-decryption
 
@@ -137,7 +137,7 @@ After the encryption step all results will be Base64 encoded for easier transpor
 RxFingerprint brings the following dependencies:
 
 - RxJava2
-- AppCompat-v7 to allow for backwards compability (which will just do nothing)
+- Android Support Annotations
 
 ## Bugs and Feedback
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -32,7 +32,7 @@ ext.versions = [
         bintrayGradlePlugin    : '1.7.1',
 
         // Dependency Versions
-        supportLibrary         : '24.2.0',
+        supportLibrary         : '25.1.1',
         rxJava                 : '2.0.1',
 
         // Testing dependencies

--- a/rxfingerprint/build.gradle
+++ b/rxfingerprint/build.gradle
@@ -45,7 +45,7 @@ android {
 
 
 dependencies {
-    compile "com.android.support:support-compat:$versions.supportLibrary"
+    compile "com.android.support:support-annotations:$versions.supportLibrary"
     compile "io.reactivex.rxjava2:rxjava:$versions.rxJava"
 
     testCompile "junit:junit:$versions.jUnit"

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintAuthenticationObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintAuthenticationObservable.java
@@ -17,8 +17,11 @@
 package com.mtramin.rxfingerprint;
 
 import android.content.Context;
+import android.hardware.fingerprint.FingerprintManager.AuthenticationResult;
+import android.hardware.fingerprint.FingerprintManager.CryptoObject;
+import android.os.Build;
 import android.support.annotation.Nullable;
-import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
+import android.support.annotation.RequiresApi;
 
 import com.mtramin.rxfingerprint.data.FingerprintAuthenticationResult;
 import com.mtramin.rxfingerprint.data.FingerprintResult;
@@ -29,6 +32,7 @@ import io.reactivex.ObservableEmitter;
 /**
  * Authenticates the user with his fingerprint.
  */
+@RequiresApi(Build.VERSION_CODES.M)
 class FingerprintAuthenticationObservable extends FingerprintObservable<FingerprintAuthenticationResult> {
 
     /**
@@ -48,13 +52,13 @@ class FingerprintAuthenticationObservable extends FingerprintObservable<Fingerpr
 
     @Nullable
     @Override
-    protected FingerprintManagerCompat.CryptoObject initCryptoObject(ObservableEmitter<FingerprintAuthenticationResult> subscriber) {
+    protected CryptoObject initCryptoObject(ObservableEmitter<FingerprintAuthenticationResult> subscriber) {
         // Simple authentication does not need CryptoObject
         return null;
     }
 
     @Override
-    protected void onAuthenticationSucceeded(ObservableEmitter<FingerprintAuthenticationResult> emitter, FingerprintManagerCompat.AuthenticationResult result) {
+    protected void onAuthenticationSucceeded(ObservableEmitter<FingerprintAuthenticationResult> emitter, AuthenticationResult result) {
         emitter.onNext(new FingerprintAuthenticationResult(FingerprintResult.AUTHENTICATED, null));
         emitter.onComplete();
     }

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintAuthenticationObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintAuthenticationObservable.java
@@ -19,9 +19,7 @@ package com.mtramin.rxfingerprint;
 import android.content.Context;
 import android.hardware.fingerprint.FingerprintManager.AuthenticationResult;
 import android.hardware.fingerprint.FingerprintManager.CryptoObject;
-import android.os.Build;
 import android.support.annotation.Nullable;
-import android.support.annotation.RequiresApi;
 
 import com.mtramin.rxfingerprint.data.FingerprintAuthenticationResult;
 import com.mtramin.rxfingerprint.data.FingerprintResult;
@@ -32,7 +30,6 @@ import io.reactivex.ObservableEmitter;
 /**
  * Authenticates the user with his fingerprint.
  */
-@RequiresApi(Build.VERSION_CODES.M)
 class FingerprintAuthenticationObservable extends FingerprintObservable<FingerprintAuthenticationResult> {
 
     /**

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintDecryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintDecryptionObservable.java
@@ -17,8 +17,11 @@
 package com.mtramin.rxfingerprint;
 
 import android.content.Context;
+import android.hardware.fingerprint.FingerprintManager.AuthenticationResult;
+import android.hardware.fingerprint.FingerprintManager.CryptoObject;
+import android.os.Build;
 import android.support.annotation.Nullable;
-import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
+import android.support.annotation.RequiresApi;
 
 import com.mtramin.rxfingerprint.data.FingerprintDecryptionResult;
 import com.mtramin.rxfingerprint.data.FingerprintEncryptionResult;
@@ -47,6 +50,7 @@ import io.reactivex.ObservableEmitter;
  * <p/>
  * The date handed in must be previously encrypted by a {@link FingerprintEncryptionObservable}.
  */
+@RequiresApi(Build.VERSION_CODES.M)
 class FingerprintDecryptionObservable extends FingerprintObservable<FingerprintDecryptionResult> {
 
 	private final String keyName;
@@ -87,12 +91,12 @@ class FingerprintDecryptionObservable extends FingerprintObservable<FingerprintD
 
 	@Nullable
 	@Override
-	protected FingerprintManagerCompat.CryptoObject initCryptoObject(ObservableEmitter<FingerprintDecryptionResult> subscriber) {
+	protected CryptoObject initCryptoObject(ObservableEmitter<FingerprintDecryptionResult> subscriber) {
 		CryptoProvider cryptoProvider = new CryptoProvider(context, keyName);
 		try {
 			CryptoData cryptoData = CryptoData.fromString(encodingProvider, encryptedString);
 			Cipher cipher = cryptoProvider.initDecryptionCipher(cryptoData.getIv());
-			return new FingerprintManagerCompat.CryptoObject(cipher);
+			return new CryptoObject(cipher);
 		} catch (CryptoDataException | NoSuchAlgorithmException | CertificateException | InvalidKeyException | KeyStoreException | InvalidAlgorithmParameterException | NoSuchPaddingException | IOException | UnrecoverableKeyException e) {
 			subscriber.onError(e);
 			return null;
@@ -100,7 +104,7 @@ class FingerprintDecryptionObservable extends FingerprintObservable<FingerprintD
 	}
 
 	@Override
-	protected void onAuthenticationSucceeded(ObservableEmitter<FingerprintDecryptionResult> emitter, FingerprintManagerCompat.AuthenticationResult result) {
+	protected void onAuthenticationSucceeded(ObservableEmitter<FingerprintDecryptionResult> emitter, AuthenticationResult result) {
 		try {
 			CryptoData cryptoData = CryptoData.fromString(encodingProvider, encryptedString);
 			Cipher cipher = result.getCryptoObject().getCipher();

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintDecryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintDecryptionObservable.java
@@ -49,6 +49,7 @@ import io.reactivex.ObservableEmitter;
  * <p/>
  * The date handed in must be previously encrypted by a {@link FingerprintEncryptionObservable}.
  */
+@SuppressLint("NewApi") // SDK check happens in {@link FingerprintObservable#subscribe}
 class FingerprintDecryptionObservable extends FingerprintObservable<FingerprintDecryptionResult> {
 
 	private final String keyName;
@@ -89,7 +90,6 @@ class FingerprintDecryptionObservable extends FingerprintObservable<FingerprintD
 
 	@Nullable
 	@Override
-	@SuppressLint("NewApi")
 	protected CryptoObject initCryptoObject(ObservableEmitter<FingerprintDecryptionResult> subscriber) {
 		CryptoProvider cryptoProvider = new CryptoProvider(context, keyName);
 		try {
@@ -103,7 +103,6 @@ class FingerprintDecryptionObservable extends FingerprintObservable<FingerprintD
 	}
 
 	@Override
-	@SuppressLint("NewApi")
 	protected void onAuthenticationSucceeded(ObservableEmitter<FingerprintDecryptionResult> emitter, AuthenticationResult result) {
 		try {
 			CryptoData cryptoData = CryptoData.fromString(encodingProvider, encryptedString);

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintDecryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintDecryptionObservable.java
@@ -16,12 +16,11 @@
 
 package com.mtramin.rxfingerprint;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.hardware.fingerprint.FingerprintManager.AuthenticationResult;
 import android.hardware.fingerprint.FingerprintManager.CryptoObject;
-import android.os.Build;
 import android.support.annotation.Nullable;
-import android.support.annotation.RequiresApi;
 
 import com.mtramin.rxfingerprint.data.FingerprintDecryptionResult;
 import com.mtramin.rxfingerprint.data.FingerprintEncryptionResult;
@@ -50,7 +49,6 @@ import io.reactivex.ObservableEmitter;
  * <p/>
  * The date handed in must be previously encrypted by a {@link FingerprintEncryptionObservable}.
  */
-@RequiresApi(Build.VERSION_CODES.M)
 class FingerprintDecryptionObservable extends FingerprintObservable<FingerprintDecryptionResult> {
 
 	private final String keyName;
@@ -91,6 +89,7 @@ class FingerprintDecryptionObservable extends FingerprintObservable<FingerprintD
 
 	@Nullable
 	@Override
+	@SuppressLint("NewApi")
 	protected CryptoObject initCryptoObject(ObservableEmitter<FingerprintDecryptionResult> subscriber) {
 		CryptoProvider cryptoProvider = new CryptoProvider(context, keyName);
 		try {
@@ -104,6 +103,7 @@ class FingerprintDecryptionObservable extends FingerprintObservable<FingerprintD
 	}
 
 	@Override
+	@SuppressLint("NewApi")
 	protected void onAuthenticationSucceeded(ObservableEmitter<FingerprintDecryptionResult> emitter, AuthenticationResult result) {
 		try {
 			CryptoData cryptoData = CryptoData.fromString(encodingProvider, encryptedString);

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintEncryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintEncryptionObservable.java
@@ -17,8 +17,11 @@
 package com.mtramin.rxfingerprint;
 
 import android.content.Context;
+import android.hardware.fingerprint.FingerprintManager.AuthenticationResult;
+import android.hardware.fingerprint.FingerprintManager.CryptoObject;
+import android.os.Build;
 import android.support.annotation.Nullable;
-import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
+import android.support.annotation.RequiresApi;
 
 import com.mtramin.rxfingerprint.data.FingerprintEncryptionResult;
 import com.mtramin.rxfingerprint.data.FingerprintResult;
@@ -48,6 +51,7 @@ import io.reactivex.ObservableEmitter;
  * can only be used with fingerprint authentication and uses it once authentication was successful
  * to encrypt the given data.
  */
+@RequiresApi(Build.VERSION_CODES.M)
 class FingerprintEncryptionObservable extends FingerprintObservable<FingerprintEncryptionResult> {
 
 	private final String keyName;
@@ -90,11 +94,11 @@ class FingerprintEncryptionObservable extends FingerprintObservable<FingerprintE
 
 	@Nullable
 	@Override
-	protected FingerprintManagerCompat.CryptoObject initCryptoObject(ObservableEmitter<FingerprintEncryptionResult> emitter) {
+	protected CryptoObject initCryptoObject(ObservableEmitter<FingerprintEncryptionResult> emitter) {
 		CryptoProvider cryptoProvider = new CryptoProvider(context, keyName);
 		try {
 			Cipher cipher = cryptoProvider.initEncryptionCipher();
-			return new FingerprintManagerCompat.CryptoObject(cipher);
+			return new CryptoObject(cipher);
 		} catch (InvalidKeyException | NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException | InvalidAlgorithmParameterException | CertificateException | UnrecoverableKeyException | KeyStoreException | IOException e) {
 			emitter.onError(e);
 			return null;
@@ -103,7 +107,7 @@ class FingerprintEncryptionObservable extends FingerprintObservable<FingerprintE
 	}
 
 	@Override
-	protected void onAuthenticationSucceeded(ObservableEmitter<FingerprintEncryptionResult> emitter, FingerprintManagerCompat.AuthenticationResult result) {
+	protected void onAuthenticationSucceeded(ObservableEmitter<FingerprintEncryptionResult> emitter, AuthenticationResult result) {
 		try {
 			Cipher cipher = result.getCryptoObject().getCipher();
 			byte[] encryptedBytes = cipher.doFinal(toEncrypt.getBytes("UTF-8"));

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintEncryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintEncryptionObservable.java
@@ -50,7 +50,7 @@ import io.reactivex.ObservableEmitter;
  * can only be used with fingerprint authentication and uses it once authentication was successful
  * to encrypt the given data.
  */
-@SuppressLint("NewApi")
+@SuppressLint("NewApi") // SDK check happens in {@link FingerprintObservable#subscribe}
 class FingerprintEncryptionObservable extends FingerprintObservable<FingerprintEncryptionResult> {
 
 	private final String keyName;

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintEncryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintEncryptionObservable.java
@@ -16,12 +16,11 @@
 
 package com.mtramin.rxfingerprint;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.hardware.fingerprint.FingerprintManager.AuthenticationResult;
 import android.hardware.fingerprint.FingerprintManager.CryptoObject;
-import android.os.Build;
 import android.support.annotation.Nullable;
-import android.support.annotation.RequiresApi;
 
 import com.mtramin.rxfingerprint.data.FingerprintEncryptionResult;
 import com.mtramin.rxfingerprint.data.FingerprintResult;
@@ -51,7 +50,7 @@ import io.reactivex.ObservableEmitter;
  * can only be used with fingerprint authentication and uses it once authentication was successful
  * to encrypt the given data.
  */
-@RequiresApi(Build.VERSION_CODES.M)
+@SuppressLint("NewApi")
 class FingerprintEncryptionObservable extends FingerprintObservable<FingerprintEncryptionResult> {
 
 	private final String keyName;

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
@@ -23,8 +23,10 @@ import android.hardware.fingerprint.FingerprintManager;
 import android.hardware.fingerprint.FingerprintManager.AuthenticationCallback;
 import android.hardware.fingerprint.FingerprintManager.AuthenticationResult;
 import android.hardware.fingerprint.FingerprintManager.CryptoObject;
+import android.os.Build;
 import android.os.CancellationSignal;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
 import android.support.annotation.RequiresPermission;
 import android.util.Log;
 
@@ -42,7 +44,7 @@ import static android.Manifest.permission.USE_FINGERPRINT;
  * Base observable for Fingerprint authentication. Provides abstract methods that allow
  * to alter the input and result of the authentication.
  */
-@SuppressLint("NewApi")
+@SuppressLint("NewApi") // SDK check happens in {@link FingerprintObservable#subscribe}
 abstract class FingerprintObservable<T> implements ObservableOnSubscribe<T> {
 
 	protected final Context context;
@@ -66,6 +68,7 @@ abstract class FingerprintObservable<T> implements ObservableOnSubscribe<T> {
 
 	@Override
 	@RequiresPermission(USE_FINGERPRINT)
+	@RequiresApi(Build.VERSION_CODES.M)
 	public void subscribe(ObservableEmitter<T> emitter) throws Exception {
 		if (RxFingerprint.isUnavailable(context)) {
 			emitter.onError(new FingerprintUnavailableException("Fingerprint authentication is not available on this device! Ensure that the device has a Fingerprint sensor and enrolled Fingerprints by calling RxFingerprint#isAvailable(Context) first"));

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
@@ -16,16 +16,15 @@
 
 package com.mtramin.rxfingerprint;
 
+import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
 import android.hardware.fingerprint.FingerprintManager;
 import android.hardware.fingerprint.FingerprintManager.AuthenticationCallback;
 import android.hardware.fingerprint.FingerprintManager.AuthenticationResult;
 import android.hardware.fingerprint.FingerprintManager.CryptoObject;
-import android.os.Build;
 import android.os.CancellationSignal;
 import android.support.annotation.Nullable;
-import android.support.annotation.RequiresApi;
 import android.support.annotation.RequiresPermission;
 import android.util.Log;
 
@@ -43,7 +42,7 @@ import static android.Manifest.permission.USE_FINGERPRINT;
  * Base observable for Fingerprint authentication. Provides abstract methods that allow
  * to alter the input and result of the authentication.
  */
-@RequiresApi(Build.VERSION_CODES.M)
+@SuppressLint("NewApi")
 abstract class FingerprintObservable<T> implements ObservableOnSubscribe<T> {
 
 	protected final Context context;

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
@@ -236,6 +236,7 @@ public class RxFingerprint {
         return context.checkSelfPermission(USE_FINGERPRINT) == PackageManager.PERMISSION_GRANTED;
     }
 
+    @RequiresApi(Build.VERSION_CODES.M)
     static FingerprintManager getFingerprintManager(Context context) {
         return (FingerprintManager) context.getSystemService(Context.FINGERPRINT_SERVICE);
     }

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
@@ -17,15 +17,22 @@
 package com.mtramin.rxfingerprint;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
+import android.hardware.fingerprint.FingerprintManager;
+import android.os.Build;
 import android.security.keystore.KeyPermanentlyInvalidatedException;
 import android.support.annotation.NonNull;
-import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
+import android.support.annotation.RequiresApi;
 
 import com.mtramin.rxfingerprint.data.FingerprintAuthenticationResult;
 import com.mtramin.rxfingerprint.data.FingerprintDecryptionResult;
 import com.mtramin.rxfingerprint.data.FingerprintEncryptionResult;
 
+import java.lang.annotation.Target;
+
 import io.reactivex.Observable;
+
+import static android.Manifest.permission.USE_FINGERPRINT;
 
 /**
  * Entry point for RxFingerprint. Contains all the base methods you need to interact with the
@@ -50,6 +57,7 @@ import io.reactivex.Observable;
  * authentication. For fingerprint authentication to be isAvailable, the device needs to contain the
  * necessary hardware (a sensor) and the user has to have enrolled at least one fingerprint.
  */
+@SuppressWarnings("NewApi")
 public class RxFingerprint {
     /**
      * Authenticate the user with his fingerprint. This will enable the fingerprint sensor on the
@@ -200,8 +208,13 @@ public class RxFingerprint {
      * @param context a context
      * @return {@code true} if fingerprint hardware exists in this device.
      */
+    @SuppressWarnings("MissingPermission")
     public static boolean isHardwareDetected(@NonNull Context context) {
-        return getFingerprintManager(context).isHardwareDetected();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return false;
+        }
+
+        return fingerprintPermissionGranted(context) && getFingerprintManager(context).isHardwareDetected();
     }
 
     /**
@@ -213,13 +226,22 @@ public class RxFingerprint {
      * @param context a context
      * @return {@code true} if at least one fingerprint was enrolled.
      */
+    @SuppressWarnings("MissingPermission")
     public static boolean hasEnrolledFingerprints(@NonNull Context context) {
-        return getFingerprintManager(context).hasEnrolledFingerprints();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return false;
+        }
+        return fingerprintPermissionGranted(context) && getFingerprintManager(context).hasEnrolledFingerprints();
     }
 
-    @NonNull
-    private static FingerprintManagerCompat getFingerprintManager(Context context) {
-        return FingerprintManagerCompat.from(context);
+    @RequiresApi(Build.VERSION_CODES.M)
+    private static boolean fingerprintPermissionGranted(Context context) {
+        return context.checkSelfPermission(USE_FINGERPRINT) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    static FingerprintManager getFingerprintManager(Context context) {
+        return (FingerprintManager) context.getSystemService(Context.FINGERPRINT_SERVICE);
     }
 
     /**

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
@@ -28,8 +28,6 @@ import com.mtramin.rxfingerprint.data.FingerprintAuthenticationResult;
 import com.mtramin.rxfingerprint.data.FingerprintDecryptionResult;
 import com.mtramin.rxfingerprint.data.FingerprintEncryptionResult;
 
-import java.lang.annotation.Target;
-
 import io.reactivex.Observable;
 
 import static android.Manifest.permission.USE_FINGERPRINT;
@@ -57,15 +55,14 @@ import static android.Manifest.permission.USE_FINGERPRINT;
  * authentication. For fingerprint authentication to be isAvailable, the device needs to contain the
  * necessary hardware (a sensor) and the user has to have enrolled at least one fingerprint.
  */
-@SuppressWarnings("NewApi")
 public class RxFingerprint {
     /**
      * Authenticate the user with his fingerprint. This will enable the fingerprint sensor on the
      * device and wait for the user to touch the sensor with his finger.
      * <p/>
-     * All possible recoverable errors will be provided in {@link rx.Subscriber#onNext(Object)} and
+     * All possible recoverable errors will be provided in {@link org.reactivestreams.Subscriber#onNext(Object)} and
      * should be handled there. Unrecoverable errors will be provided with
-     * {@link rx.Subscriber#onError(Throwable)} calls.
+     * {@link org.reactivestreams.Subscriber#onError(Throwable)} calls.
      *
      * @param context current context
      * @return Observable {@link FingerprintAuthenticationResult}. Will complete once the
@@ -239,7 +236,6 @@ public class RxFingerprint {
         return context.checkSelfPermission(USE_FINGERPRINT) == PackageManager.PERMISSION_GRANTED;
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     static FingerprintManager getFingerprintManager(Context context) {
         return (FingerprintManager) context.getSystemService(Context.FINGERPRINT_SERVICE);
     }
@@ -254,7 +250,7 @@ public class RxFingerprint {
      * invalidated by the Android system. To continue using encryption you have to ask the user to
      * encrypt the original data again. The old data is not accessible anymore.
      *
-     * @param throwable Throwable received in {@link rx.Subscriber#onError(Throwable)} from
+     * @param throwable Throwable received in {@link org.reactivestreams.Subscriber#onError(Throwable)} from
      *                  an {@link RxFingerprint} encryption method
      * @return {@code true} if the requested key was permanently invalidated and cannot be used
      * anymore

--- a/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/RxFingerprintTest.java
+++ b/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/RxFingerprintTest.java
@@ -1,8 +1,9 @@
 package com.mtramin.rxfingerprint;
 
 import android.content.Context;
+import android.hardware.fingerprint.FingerprintManager;
+import android.os.Build;
 import android.security.keystore.KeyPermanentlyInvalidatedException;
-import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -20,20 +21,22 @@ import static org.mockito.MockitoAnnotations.initMocks;
 /**
  * Tests for various helper methods included in {@link RxFingerprint}
  */
+@SuppressWarnings({"NewApi", "MissingPermission"})
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({FingerprintManagerCompat.class})
+@PrepareForTest({FingerprintManager.class})
 public class RxFingerprintTest {
 
     @Mock
     Context mockContext;
 
     @Mock
-    FingerprintManagerCompat mockFingerprintManager;
+    FingerprintManager mockFingerprintManager;
 
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        PowerMockito.mockStatic(FingerprintManagerCompat.class);
+        TestHelper.setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 23);
+        PowerMockito.mockStatic(FingerprintManager.class);
     }
 
     @Test
@@ -44,7 +47,7 @@ public class RxFingerprintTest {
 
     @Test
     public void testAvailable() throws Exception {
-        when(FingerprintManagerCompat.from(mockContext)).thenReturn(mockFingerprintManager);
+        when(mockContext.getSystemService(Context.FINGERPRINT_SERVICE)).thenReturn(mockFingerprintManager);
         when(mockFingerprintManager.isHardwareDetected()).thenReturn(true);
         when(mockFingerprintManager.hasEnrolledFingerprints()).thenReturn(true);
 
@@ -54,7 +57,7 @@ public class RxFingerprintTest {
 
     @Test
     public void testUnavailableWithNoHardware() throws Exception {
-        when(FingerprintManagerCompat.from(mockContext)).thenReturn(mockFingerprintManager);
+        when(mockContext.getSystemService(Context.FINGERPRINT_SERVICE)).thenReturn(mockFingerprintManager);
         when(mockFingerprintManager.isHardwareDetected()).thenReturn(false);
         when(mockFingerprintManager.hasEnrolledFingerprints()).thenReturn(true);
 
@@ -64,7 +67,7 @@ public class RxFingerprintTest {
 
     @Test
     public void testUnavailableWithNoFingerprint() throws Exception {
-        when(FingerprintManagerCompat.from(mockContext)).thenReturn(mockFingerprintManager);
+        when(mockContext.getSystemService(Context.FINGERPRINT_SERVICE)).thenReturn(mockFingerprintManager);
         when(mockFingerprintManager.isHardwareDetected()).thenReturn(true);
         when(mockFingerprintManager.hasEnrolledFingerprints()).thenReturn(false);
 
@@ -74,7 +77,7 @@ public class RxFingerprintTest {
 
     @Test
     public void testUnavailable() throws Exception {
-        when(FingerprintManagerCompat.from(mockContext)).thenReturn(mockFingerprintManager);
+        when(mockContext.getSystemService(Context.FINGERPRINT_SERVICE)).thenReturn(mockFingerprintManager);
         when(mockFingerprintManager.isHardwareDetected()).thenReturn(false);
         when(mockFingerprintManager.hasEnrolledFingerprints()).thenReturn(false);
 
@@ -84,7 +87,7 @@ public class RxFingerprintTest {
 
     @Test
     public void fingerprintAvailable() throws Exception {
-        when(FingerprintManagerCompat.from(mockContext)).thenReturn(mockFingerprintManager);
+        when(mockContext.getSystemService(Context.FINGERPRINT_SERVICE)).thenReturn(mockFingerprintManager);
         when(mockFingerprintManager.hasEnrolledFingerprints()).thenReturn(true);
 
         assertTrue("Fingerprint should be available", RxFingerprint.hasEnrolledFingerprints(mockContext));
@@ -92,7 +95,7 @@ public class RxFingerprintTest {
 
     @Test
     public void hardwareAvailable() throws Exception {
-        when(FingerprintManagerCompat.from(mockContext)).thenReturn(mockFingerprintManager);
+        when(mockContext.getSystemService(Context.FINGERPRINT_SERVICE)).thenReturn(mockFingerprintManager);
         when(mockFingerprintManager.isHardwareDetected()).thenReturn(true);
 
         assertTrue("Hardware should be available", RxFingerprint.isHardwareDetected(mockContext));
@@ -100,7 +103,7 @@ public class RxFingerprintTest {
 
     @Test
     public void fingerprintUnavailable() throws Exception {
-        when(FingerprintManagerCompat.from(mockContext)).thenReturn(mockFingerprintManager);
+        when(mockContext.getSystemService(Context.FINGERPRINT_SERVICE)).thenReturn(mockFingerprintManager);
         when(mockFingerprintManager.hasEnrolledFingerprints()).thenReturn(false);
 
         assertFalse("Fingerprint should be unavailable", RxFingerprint.hasEnrolledFingerprints(mockContext));
@@ -108,7 +111,7 @@ public class RxFingerprintTest {
 
     @Test
     public void hardwareUnavailable() throws Exception {
-        when(FingerprintManagerCompat.from(mockContext)).thenReturn(mockFingerprintManager);
+        when(mockContext.getSystemService(Context.FINGERPRINT_SERVICE)).thenReturn(mockFingerprintManager);
         when(mockFingerprintManager.isHardwareDetected()).thenReturn(false);
 
         assertFalse("Hardware should be available", RxFingerprint.isHardwareDetected(mockContext));

--- a/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/RxFingerprintTest.java
+++ b/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/RxFingerprintTest.java
@@ -35,7 +35,7 @@ public class RxFingerprintTest {
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        TestHelper.setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 23);
+        TestHelper.setSdkLevel(23);
         PowerMockito.mockStatic(FingerprintManager.class);
     }
 

--- a/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/TestHelper.java
+++ b/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/TestHelper.java
@@ -1,0 +1,16 @@
+package com.mtramin.rxfingerprint;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+public class TestHelper {
+	static void setFinalStatic(Field field, Object newValue) throws Exception {
+		field.setAccessible(true);
+
+		Field modifiersField = Field.class.getDeclaredField("modifiers");
+		modifiersField.setAccessible(true);
+		modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+		field.set(null, newValue);
+	}
+}

--- a/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/TestHelper.java
+++ b/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/TestHelper.java
@@ -1,16 +1,20 @@
 package com.mtramin.rxfingerprint;
 
+import android.os.Build;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
 public class TestHelper {
-	static void setFinalStatic(Field field, Object newValue) throws Exception {
+	static void setSdkLevel(int level) throws Exception {
+		Field field = Build.VERSION.class.getField("SDK_INT");
+
 		field.setAccessible(true);
 
 		Field modifiersField = Field.class.getDeclaredField("modifiers");
 		modifiersField.setAccessible(true);
 		modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
 
-		field.set(null, newValue);
+		field.set(null, level);
 	}
 }


### PR DESCRIPTION
Removes all AppCompat usages from RxFingerprint. All usages of FingerprintManagerCompat are replaced by FingerprintManager directly to work around the wrongly defined system features in some devices.

Adds checking the SDK version manually which was previously done in AppCompat. 

Resolves #30 