### PR TITLE
emit FingerprintUnavailableException when RxFingerprint is not available

### DIFF
--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
@@ -26,6 +26,7 @@ import android.support.v4.os.CancellationSignal;
 import android.util.Log;
 
 import com.mtramin.rxfingerprint.data.FingerprintAuthenticationException;
+import com.mtramin.rxfingerprint.data.FingerprintUnavailableException;
 
 import io.reactivex.Emitter;
 import io.reactivex.ObservableEmitter;
@@ -59,8 +60,8 @@ abstract class FingerprintObservable<T> implements ObservableOnSubscribe<T> {
 
 	@Override
 	public void subscribe(ObservableEmitter<T> emitter) throws Exception {
-		if (!RxFingerprint.isAvailable(context)) {
-			emitter.onError(new IllegalAccessException("Fingerprint authentication is not available on this device! Ensure that the device has a Fingerprint sensor and enrolled Fingerprints by calling RxFingerprint#available(Context) first"));
+		if (RxFingerprint.isUnavailable(context)) {
+			emitter.onError(new FingerprintUnavailableException("Fingerprint authentication is not available on this device! Ensure that the device has a Fingerprint sensor and enrolled Fingerprints by calling RxFingerprint#isAvailable(Context) first"));
 		}
 
 		AuthenticationCallback callback = createAuthenticationCallback(emitter);

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/data/FingerprintUnavailableException.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/data/FingerprintUnavailableException.java
@@ -1,0 +1,25 @@
+package com.mtramin.rxfingerprint.data;
+
+import android.content.Context;
+
+/**
+ * Exception thrown when fingerprint operations are invoked even though the current device doesn't
+ * support it.
+ * <p>
+ * This can be the case if:
+ * - The device is on SDK <23 (pre-Marshmallow)
+ * - The device doesn't have a fingerprint sensor
+ * - The user doesn't have any fingerprints set up
+ * - The current application doesn't specify the {@link android.permission.USE_FINGERPRINT}
+ * permission
+ * <p>
+ * To avoid receiving this exception after calling RxFingerprint operations prefer calling
+ * {@link com.mtramin.rxfingerprint.RxFingerprint#isAvailable(Context)} to verify fingerprint
+ * operations are available.
+ */
+public class FingerprintUnavailableException extends Exception {
+
+	public FingerprintUnavailableException(String s) {
+		super(s);
+	}
+}

--- a/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/FingerprintAuthenticationTest.java
+++ b/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/FingerprintAuthenticationTest.java
@@ -8,6 +8,7 @@ import android.support.v4.os.CancellationSignal;
 import com.mtramin.rxfingerprint.data.FingerprintAuthenticationException;
 import com.mtramin.rxfingerprint.data.FingerprintAuthenticationResult;
 import com.mtramin.rxfingerprint.data.FingerprintResult;
+import com.mtramin.rxfingerprint.data.FingerprintUnavailableException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -52,17 +53,17 @@ public class FingerprintAuthenticationTest {
 
         when(mockContext.getApplicationContext()).thenReturn(mockContext);
         when(FingerprintManagerCompat.from(mockContext)).thenReturn(mockFingerprintManager);
-        when(RxFingerprint.isAvailable(mockContext)).thenReturn(true);
+        when(RxFingerprint.isUnavailable(mockContext)).thenReturn(false);
     }
 
     @Test
     public void testFingerprintNotAvailable() throws Exception {
-        when(RxFingerprint.isAvailable(mockContext)).thenReturn(false);
+        when(RxFingerprint.isUnavailable(mockContext)).thenReturn(true);
         TestObserver<FingerprintAuthenticationResult> testObserver = FingerprintAuthenticationObservable.create(mockContext).test();
 
         testObserver.awaitTerminalEvent();
         testObserver.assertNoValues();
-        testObserver.assertError(IllegalAccessException.class);
+        testObserver.assertError(FingerprintUnavailableException.class);
     }
 
 


### PR DESCRIPTION
Improves error clarity when a fingerprint operation is called although the device doesn't support fingerprints at the moment.