### PR TITLE
Add possibility for custom Log implementations and to disable logging

### DIFF
--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/CipherProvider.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/CipherProvider.java
@@ -22,7 +22,6 @@ import android.os.Build;
 import android.security.keystore.KeyPermanentlyInvalidatedException;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -66,7 +65,7 @@ abstract class CipherProvider {
 		try {
 			return cipherForEncryption();
 		} catch (KeyPermanentlyInvalidatedException e) {
-			Log.w("RxFingerprint", "Renewing invalidated key.");
+			Logger.warn("Renewing invalidated key.");
 			removeKey(keyName);
 			return cipherForEncryption();
 		}

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/DefaultLogger.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/DefaultLogger.java
@@ -1,0 +1,17 @@
+package com.mtramin.rxfingerprint;
+
+import android.util.Log;
+
+class DefaultLogger implements RxFingerprintLogger {
+	private static final String TAG = "RxFingerprint";
+
+	@Override
+	public void warn(String message) {
+		Log.w(TAG, message);
+	}
+
+	@Override
+	public void error(String message, Throwable throwable) {
+		Log.e(TAG, message, throwable);
+	}
+}

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintApiWrapper.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintApiWrapper.java
@@ -25,7 +25,6 @@ import android.os.Build;
 import android.os.CancellationSignal;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import static android.Manifest.permission.USE_FINGERPRINT;
 
@@ -43,7 +42,7 @@ class FingerprintApiWrapper {
 		// authentication action which will immediately onError and unsubscribe the 2nd
 		// authentication action.
 		if (context instanceof Application) {
-			Log.w("RxFingerprint", "Passing an Application Context to RxFingerprint might cause issues when the authentication is active and the application changes orientation. Consider passing an Activity Context.");
+			Logger.warn("Passing an Application Context to RxFingerprint might cause issues when the authentication is active and the application changes orientation. Consider passing an Activity Context.");
 		}
 
 		this.context = context;
@@ -100,7 +99,7 @@ class FingerprintApiWrapper {
 		try {
 			return (FingerprintManager) context.getSystemService(Context.FINGERPRINT_SERVICE);
 		} catch (Exception | NoClassDefFoundError e) {
-			Log.e("RxFingerprint", "Device with SDK >=23 doesn't provide Fingerprint APIs", e);
+			Logger.error("Device with SDK >=23 doesn't provide Fingerprint APIs", e);
 		}
 		return null;
 	}

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/FingerprintObservable.java
@@ -17,8 +17,6 @@
 package com.mtramin.rxfingerprint;
 
 import android.annotation.SuppressLint;
-import android.app.Application;
-import android.content.Context;
 import android.hardware.fingerprint.FingerprintManager;
 import android.hardware.fingerprint.FingerprintManager.AuthenticationCallback;
 import android.hardware.fingerprint.FingerprintManager.AuthenticationResult;
@@ -28,7 +26,6 @@ import android.os.CancellationSignal;
 import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
 import android.support.annotation.RequiresPermission;
-import android.util.Log;
 
 import com.mtramin.rxfingerprint.data.FingerprintAuthenticationException;
 import com.mtramin.rxfingerprint.data.FingerprintUnavailableException;

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/Logger.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/Logger.java
@@ -1,0 +1,45 @@
+package com.mtramin.rxfingerprint;
+
+class Logger {
+	private static RxFingerprintLogger logger;
+	private static boolean shouldLog = true;
+
+	private Logger() {
+		// hide
+	}
+
+	static void warn(String message) {
+		if (!shouldLog) {
+			return;
+		}
+
+		if (logger == null) {
+			createDefaultLogger();
+		}
+		logger.warn(message);
+	}
+
+	static void error(String message, Throwable throwable) {
+		if (!shouldLog) {
+			return;
+		}
+
+		if (logger == null) {
+			createDefaultLogger();
+		}
+
+		logger.error(message, throwable);
+	}
+
+	static void disableLogging() {
+		shouldLog = false;
+	}
+
+	static void setLogger(RxFingerprintLogger logger) {
+		Logger.logger = logger;
+	}
+
+	private static void createDefaultLogger() {
+		logger = new DefaultLogger();
+	}
+}

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaDecryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaDecryptionObservable.java
@@ -21,7 +21,6 @@ import android.content.Context;
 import android.hardware.fingerprint.FingerprintManager.AuthenticationResult;
 import android.hardware.fingerprint.FingerprintManager.CryptoObject;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import com.mtramin.rxfingerprint.data.FingerprintDecryptionResult;
 import com.mtramin.rxfingerprint.data.FingerprintEncryptionResult;
@@ -32,7 +31,8 @@ import javax.crypto.Cipher;
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
 
-@SuppressLint("NewApi") // SDK check happens in {@link FingerprintObservable#subscribe}
+@SuppressLint("NewApi")
+		// SDK check happens in {@link FingerprintObservable#subscribe}
 class RsaDecryptionObservable extends FingerprintObservable<FingerprintDecryptionResult> {
 
 	private final RsaCipherProvider cipherProvider;
@@ -91,7 +91,7 @@ class RsaDecryptionObservable extends FingerprintObservable<FingerprintDecryptio
 			emitter.onNext(new FingerprintDecryptionResult(FingerprintResult.AUTHENTICATED, null, decrypted));
 			emitter.onComplete();
 		} catch (Exception e) {
-			Log.e("RxFingerprint", "Unable to decrypt given value. RxFingerprint is only able to decrypt values previously encrypted by RxFingerprint with the same encryption mode.");
+			Logger.error("Unable to decrypt given value. RxFingerprint is only able to decrypt values previously encrypted by RxFingerprint with the same encryption mode.", e);
 			emitter.onError(e);
 		}
 

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaEncryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaEncryptionObservable.java
@@ -18,7 +18,6 @@ package com.mtramin.rxfingerprint;
 
 import android.content.Context;
 import android.support.annotation.VisibleForTesting;
-import android.util.Log;
 
 import com.mtramin.rxfingerprint.data.FingerprintEncryptionResult;
 import com.mtramin.rxfingerprint.data.FingerprintResult;
@@ -85,7 +84,7 @@ class RsaEncryptionObservable implements ObservableOnSubscribe<FingerprintEncryp
 			emitter.onNext(new FingerprintEncryptionResult(FingerprintResult.AUTHENTICATED, null, encryptedString));
 			emitter.onComplete();
 		} catch (Exception e) {
-			Log.w("RxFingerprint", String.format("Error writing value for key: %s", cipherProvider.keyName), e);
+			Logger.error(String.format("Error writing value for key: %s", cipherProvider.keyName), e);
 			emitter.onError(e);
 		}
 	}

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
@@ -287,6 +287,21 @@ public class RxFingerprint {
     }
 
     /**
+     * Disables logging for RxFingerprint
+     */
+    public void disableLogging() {
+        Logger.disableLogging();
+    }
+
+    /**
+     * Set a custom logger for RxFingerprint.
+     * @param logger Logger implementation to use for custom logging.
+     */
+    public void setLogger(RxFingerprintLogger logger) {
+        Logger.setLogger(logger);
+    }
+
+    /**
      * Checks if the provided {@link Throwable} is of type {@link KeyPermanentlyInvalidatedException}
      * <p/>
      * This would mean that the user has disabled the lock screen on his device or changed the

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
@@ -287,13 +287,6 @@ public class RxFingerprint {
     }
 
     /**
-     * Disables logging for RxFingerprint
-     */
-    public void disableLogging() {
-        Logger.disableLogging();
-    }
-
-    /**
      * Set a custom logger for RxFingerprint.
      * @param logger Logger implementation to use for custom logging.
      */
@@ -301,6 +294,14 @@ public class RxFingerprint {
         Logger.setLogger(logger);
     }
 
+    /**
+     * Disables all logging in RxFingerprint. This also affects any custom logger set by
+     * {@link #setLogger(RxFingerprintLogger)}.
+     */
+    public void disableLogging() {
+        Logger.disableLogging();
+    }
+    
     /**
      * Checks if the provided {@link Throwable} is of type {@link KeyPermanentlyInvalidatedException}
      * <p/>

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
@@ -290,7 +290,7 @@ public class RxFingerprint {
      * Set a custom logger for RxFingerprint.
      * @param logger Logger implementation to use for custom logging.
      */
-    public void setLogger(RxFingerprintLogger logger) {
+    public static void setLogger(RxFingerprintLogger logger) {
         Logger.setLogger(logger);
     }
 
@@ -298,7 +298,7 @@ public class RxFingerprint {
      * Disables all logging in RxFingerprint. This also affects any custom logger set by
      * {@link #setLogger(RxFingerprintLogger)}.
      */
-    public void disableLogging() {
+    public static void disableLogging() {
         Logger.disableLogging();
     }
     

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprintLogger.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprintLogger.java
@@ -1,0 +1,21 @@
+package com.mtramin.rxfingerprint;
+
+/**
+ * Logger for RxFingerprint to support custom logging behavior
+ */
+public interface RxFingerprintLogger {
+
+	/**
+	 * Log a warning message
+	 *
+	 * @param message
+	 */
+	void warn(String message);
+
+	/**
+	 * Log an error message
+	 *
+	 * @param message
+	 */
+	void error(String message, Throwable throwable);
+}

--- a/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/FingerprintApiWrapperTest.java
+++ b/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/FingerprintApiWrapperTest.java
@@ -20,38 +20,29 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.hardware.fingerprint.FingerprintManager;
-import android.util.Log;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static android.Manifest.permission.USE_FINGERPRINT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @SuppressLint("MissingPermission")
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(Log.class)
+@RunWith(MockitoJUnitRunner.class)
 public class FingerprintApiWrapperTest {
 
-	@Mock
-	Context context;
-
-	@Mock
-	FingerprintManager fingerprintManager;
+	@Mock Context context;
+	@Mock FingerprintManager fingerprintManager;
 
 	@Before
 	public void setUp() throws Exception {
-		initMocks(this);
-		mockStatic(Log.class);
+		RxFingerprint.disableLogging();
 	}
 
 	@Test

--- a/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/RsaEncryptionObservableTest.java
+++ b/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/RsaEncryptionObservableTest.java
@@ -16,8 +16,6 @@
 
 package com.mtramin.rxfingerprint;
 
-import android.util.Log;
-
 import com.mtramin.rxfingerprint.data.FingerprintEncryptionResult;
 import com.mtramin.rxfingerprint.data.FingerprintUnavailableException;
 
@@ -38,24 +36,22 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Log.class, Cipher.class})
+@PrepareForTest(Cipher.class)
 public class RsaEncryptionObservableTest {
 
 	private static final String INPUT = "TEST";
 
-	@Mock
-	FingerprintApiWrapper fingerprintApiWrapper;
-	@Mock
-	RsaCipherProvider cipherProvider;
+	@Mock FingerprintApiWrapper fingerprintApiWrapper;
+	@Mock RsaCipherProvider cipherProvider;
 	Cipher cipher;
 
 	private Observable<FingerprintEncryptionResult> observable;
 
 	@Before
 	public void setUp() throws Exception {
-		mockStatic(Log.class);
 		mockStatic(Cipher.class);
 		cipher = mock(Cipher.class);
+		RxFingerprint.disableLogging();
 
 		observable = Observable.create(new RsaEncryptionObservable(fingerprintApiWrapper, cipherProvider, INPUT, new TestEncodingProvider()));
 	}

--- a/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/RxFingerprintTest.java
+++ b/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/RxFingerprintTest.java
@@ -23,17 +23,15 @@ import static org.mockito.MockitoAnnotations.initMocks;
  */
 @SuppressWarnings({"NewApi", "MissingPermission"})
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({FingerprintManager.class, Log.class})
+@PrepareForTest(FingerprintManager.class)
 public class RxFingerprintTest {
 
-    @Mock
-    Context mockContext;
-
-    @Mock
-    FingerprintManager mockFingerprintManager;
+    @Mock Context mockContext;
+    @Mock FingerprintManager mockFingerprintManager;
 
     @Before
     public void setUp() throws Exception {
+        RxFingerprint.disableLogging();
         initMocks(this);
         TestHelper.setSdkLevel(23);
         PowerMockito.mockStatic(FingerprintManager.class);

--- a/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/TestHelper.java
+++ b/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/TestHelper.java
@@ -5,7 +5,7 @@ import android.os.Build;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-public class TestHelper {
+class TestHelper {
 	static void setSdkLevel(int level) throws Exception {
 		Field field = Build.VERSION.class.getField("SDK_INT");
 


### PR DESCRIPTION
Resolves #37 

Adds a new `RxFingerprintLogger` interface to support custom means of logging. By default `DefaultLogger` will be used.

`RxFingerprint` gains two methods:
- `setLogger` to set a custom logger implementation to be used by RxFingerprint
- `disableLogging` to disable all logging 