### PR TITLE
move all dependency declarations to dependencies.gradle

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -15,36 +15,52 @@
  */
 
 ext.versions = [
-        // Version
-        code                   : 1,
-        name                   : '2.1.0',
+		// Version
+		code                   : 1,
+		name                   : '2.1.0',
 
-        // Android Versions
-        compileSdk             : 25,
-        targetSdk              : 25,
-        minSdk                 : 15,
-        buildTools             : '25.0.2',
+		// Android Versions
+		compileSdk             : 25,
+		targetSdk              : 25,
+		minSdk                 : 15,
+		buildTools             : '25.0.2',
 
-        // Gradle Versions
-        androidGradlePlugin    : '2.2.1',
-        retrolambdaGradlePlugin: '3.2.5',
-        mavenGradlePlugin      : '1.4.1',
-        bintrayGradlePlugin    : '1.7.1',
+		// Gradle Versions
+		androidGradlePlugin    : '2.2.1',
+		retrolambdaGradlePlugin: '3.2.5',
+		mavenGradlePlugin      : '1.4.1',
+		bintrayGradlePlugin    : '1.7.1',
 
-        // Dependency Versions
-        supportLibrary         : '25.3.0',
-        rxJava                 : '2.0.8',
+		// Dependency Versions
+		supportLibrary         : '25.3.0',
+		rxJava                 : '2.0.8',
 
-        // Testing dependencies
-        jUnit : '4.12',
-        mockito : '1.10.19',
-        powermock : '1.6.4',
-        testRunner : '0.5'
+		// Testing dependencies
+		jUnit                  : '4.12',
+		mockito                : '1.10.19',
+		powermock              : '1.6.4',
+		testRunner             : '0.5'
 ]
 
 ext.gradlePlugins = [
-        android    : "com.android.tools.build:gradle:$versions.androidGradlePlugin",
-        retrolambda: "me.tatarka:gradle-retrolambda:$versions.retrolambdaGradlePlugin",
-        maven      : "com.github.dcendents:android-maven-gradle-plugin:$versions.mavenGradlePlugin",
-        bintray    : "com.jfrog.bintray.gradle:gradle-bintray-plugin:$versions.bintrayGradlePlugin"
+		android    : "com.android.tools.build:gradle:$versions.androidGradlePlugin",
+		retrolambda: "me.tatarka:gradle-retrolambda:$versions.retrolambdaGradlePlugin",
+		maven      : "com.github.dcendents:android-maven-gradle-plugin:$versions.mavenGradlePlugin",
+		bintray    : "com.jfrog.bintray.gradle:gradle-bintray-plugin:$versions.bintrayGradlePlugin"
+]
+
+ext.libraries = [
+		// RxFingerprint dependencies
+		supportAnnotations: "com.android.support:support-annotations:$versions.supportLibrary",
+		rxJava            : "io.reactivex.rxjava2:rxjava:$versions.rxJava",
+
+		// Sample dependencies
+		appCompat         : "com.android.support:appcompat-v7:$versions.supportLibrary",
+
+		// Test dependencies
+		jUnit             : "junit:junit:$versions.jUnit",
+		mockito           : "org.mockito:mockito-core:$versions.mockito",
+		powermockJUnit    : "org.powermock:powermock-api-mockito:$versions.powermock",
+		powermockMockito  : "org.powermock:powermock-module-junit4:$versions.powermock",
+
 ]

--- a/rxfingerprint/build.gradle
+++ b/rxfingerprint/build.gradle
@@ -20,28 +20,28 @@ group 'com.mtramin'
 version versions.name
 
 android {
-    compileSdkVersion versions.compileSdk
-    buildToolsVersion versions.buildTools
+	compileSdkVersion versions.compileSdk
+	buildToolsVersion versions.buildTools
 
-    defaultConfig {
-        minSdkVersion versions.minSdk
-        targetSdkVersion versions.targetSdk
-        versionCode versions.code
-        versionName versions.name
-    }
+	defaultConfig {
+		minSdkVersion versions.minSdk
+		targetSdkVersion versions.targetSdk
+		versionCode versions.code
+		versionName versions.name
+	}
 
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
+	buildTypes {
+		release {
+			minifyEnabled false
+			proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+		}
+	}
 
-    lintOptions {
-        textReport true
-    }
+	lintOptions {
+		textReport true
+	}
 
-    testOptions {
+	testOptions {
 		unitTests.all {
 			testLogging {
 				events 'passed', 'skipped', 'failed'
@@ -51,16 +51,14 @@ android {
 	}
 }
 
-
-
 dependencies {
-    compile "com.android.support:support-annotations:$versions.supportLibrary"
-    compile "io.reactivex.rxjava2:rxjava:$versions.rxJava"
+	compile libraries.supportAnnotations
+	compile libraries.rxJava
 
-    testCompile "junit:junit:$versions.jUnit"
-    testCompile "org.mockito:mockito-core:$versions.mockito"
-    testCompile "org.powermock:powermock-module-junit4:$versions.powermock"
-    testCompile "org.powermock:powermock-api-mockito:$versions.powermock"
+	testCompile libraries.jUnit
+	testCompile libraries.mockito
+	testCompile libraries.powermockJUnit
+	testCompile libraries.powermockMockito
 }
 
 //apply from: 'publish.gradle'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -46,5 +46,5 @@ dependencies {
     compile project(':rxfingerprint');
 //    compile "com.mtramin:rxfingerprint:$versions.name"
 
-    compile "com.android.support:appcompat-v7:$versions.supportLibrary"
+    compile libraries.appCompat
 }


### PR DESCRIPTION
Cleans up the `build.gradle` files in RxFingerprint and the sample slightly