### PR TITLE
Allow key to be not invalidated upon biometric enrollment.

### DIFF
--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesCipherProvider.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesCipherProvider.java
@@ -42,18 +42,18 @@ class AesCipherProvider extends CipherProvider {
 	private static final int AES_KEY_SIZE = 256;
 
 	AesCipherProvider(@NonNull Context context, @Nullable String keyName) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
-                this(context, keyName, true);
+               this(context, keyName, true);
        }
 
        AesCipherProvider(@NonNull Context context, @Nullable String keyName, boolean keyInvalidatedByBiometricEnrollment) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
-                super(context, keyName, keyInvalidatedByBiometricEnrollment);
+               super(context, keyName, keyInvalidatedByBiometricEnrollment);
        }
 
 	private SecretKey findOrCreateKey(String keyName) throws NoSuchProviderException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, UnrecoverableKeyException, CertificateException, KeyStoreException, IOException {
 		if (keyExists(keyName)) {
 			return getKey(keyName);
 		}
-                return createKey(keyName, invalidatedByBiometricEnrollment);
+               return createKey(keyName, invalidatedByBiometricEnrollment);
        }
 
 	private SecretKey getKey(String keyName) throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
@@ -62,11 +62,11 @@ class AesCipherProvider extends CipherProvider {
 
 	@TargetApi(Build.VERSION_CODES.M)
        private static SecretKey createKey(String keyName, boolean invalidatedByBiometricEnrollment) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
-                KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
-                keyGenerator.init(getKeyGenParameterSpecBuilder(keyName, KeyProperties.BLOCK_MODE_CBC, KeyProperties.ENCRYPTION_PADDING_PKCS7, invalidatedByBiometricEnrollment)
-                        .setKeySize(AES_KEY_SIZE)
-                        .build());
-                return keyGenerator.generateKey();
+               KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
+               keyGenerator.init(getKeyGenParameterSpecBuilder(keyName, KeyProperties.BLOCK_MODE_CBC, KeyProperties.ENCRYPTION_PADDING_PKCS7, invalidatedByBiometricEnrollment)
+                       .setKeySize(AES_KEY_SIZE)
+                       .build());
+               return keyGenerator.generateKey();
        }
 
 	@Override

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesCipherProvider.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesCipherProvider.java
@@ -42,32 +42,32 @@ class AesCipherProvider extends CipherProvider {
 	private static final int AES_KEY_SIZE = 256;
 
 	AesCipherProvider(@NonNull Context context, @Nullable String keyName) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
-        this(context, keyName, true);
-    }
+            this(context, keyName, true);
+        }
 
-    AesCipherProvider(@NonNull Context context, @Nullable String keyName, boolean keyInvalidatedByBiometricEnrollment) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
-        super(context, keyName, keyInvalidatedByBiometricEnrollment);
-    }
+        AesCipherProvider(@NonNull Context context, @Nullable String keyName, boolean keyInvalidatedByBiometricEnrollment) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+            super(context, keyName, keyInvalidatedByBiometricEnrollment);
+        }
 
 	private SecretKey findOrCreateKey(String keyName) throws NoSuchProviderException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, UnrecoverableKeyException, CertificateException, KeyStoreException, IOException {
 		if (keyExists(keyName)) {
 			return getKey(keyName);
 		}
-        return createKey(keyName, invalidatedByBiometricEnrollment);
-    }
+            return createKey(keyName, invalidatedByBiometricEnrollment);
+        }
 
 	private SecretKey getKey(String keyName) throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
 		return (SecretKey) keyStore.getKey(keyName, null);
 	}
 
 	@TargetApi(Build.VERSION_CODES.M)
-    private static SecretKey createKey(String keyName, boolean invalidatedByBiometricEnrollment) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
-        KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
-        keyGenerator.init(getKeyGenParameterSpecBuilder(keyName, KeyProperties.BLOCK_MODE_CBC, KeyProperties.ENCRYPTION_PADDING_PKCS7, invalidatedByBiometricEnrollment)
-                .setKeySize(AES_KEY_SIZE)
-                .build());
-        return keyGenerator.generateKey();
-    }
+        private static SecretKey createKey(String keyName, boolean invalidatedByBiometricEnrollment) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
+            KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
+            keyGenerator.init(getKeyGenParameterSpecBuilder(keyName, KeyProperties.BLOCK_MODE_CBC, KeyProperties.ENCRYPTION_PADDING_PKCS7, invalidatedByBiometricEnrollment)
+                    .setKeySize(AES_KEY_SIZE)
+                    .build());
+            return keyGenerator.generateKey();
+        }
 
 	@Override
 	Cipher cipherForEncryption() throws NoSuchAlgorithmException, NoSuchPaddingException, CertificateException, UnrecoverableKeyException, KeyStoreException, NoSuchProviderException, InvalidAlgorithmParameterException, IOException, InvalidKeyException {

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesCipherProvider.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesCipherProvider.java
@@ -42,32 +42,32 @@ class AesCipherProvider extends CipherProvider {
 	private static final int AES_KEY_SIZE = 256;
 
 	AesCipherProvider(@NonNull Context context, @Nullable String keyName) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
-            this(context, keyName, true);
-        }
+                this(context, keyName, true);
+       }
 
-        AesCipherProvider(@NonNull Context context, @Nullable String keyName, boolean keyInvalidatedByBiometricEnrollment) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
-            super(context, keyName, keyInvalidatedByBiometricEnrollment);
-        }
+       AesCipherProvider(@NonNull Context context, @Nullable String keyName, boolean keyInvalidatedByBiometricEnrollment) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+                super(context, keyName, keyInvalidatedByBiometricEnrollment);
+       }
 
 	private SecretKey findOrCreateKey(String keyName) throws NoSuchProviderException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, UnrecoverableKeyException, CertificateException, KeyStoreException, IOException {
 		if (keyExists(keyName)) {
 			return getKey(keyName);
 		}
-            return createKey(keyName, invalidatedByBiometricEnrollment);
-        }
+                return createKey(keyName, invalidatedByBiometricEnrollment);
+       }
 
 	private SecretKey getKey(String keyName) throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
 		return (SecretKey) keyStore.getKey(keyName, null);
 	}
 
 	@TargetApi(Build.VERSION_CODES.M)
-        private static SecretKey createKey(String keyName, boolean invalidatedByBiometricEnrollment) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
-            KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
-            keyGenerator.init(getKeyGenParameterSpecBuilder(keyName, KeyProperties.BLOCK_MODE_CBC, KeyProperties.ENCRYPTION_PADDING_PKCS7, invalidatedByBiometricEnrollment)
-                    .setKeySize(AES_KEY_SIZE)
-                    .build());
-            return keyGenerator.generateKey();
-        }
+       private static SecretKey createKey(String keyName, boolean invalidatedByBiometricEnrollment) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
+                KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
+                keyGenerator.init(getKeyGenParameterSpecBuilder(keyName, KeyProperties.BLOCK_MODE_CBC, KeyProperties.ENCRYPTION_PADDING_PKCS7, invalidatedByBiometricEnrollment)
+                        .setKeySize(AES_KEY_SIZE)
+                        .build());
+                return keyGenerator.generateKey();
+       }
 
 	@Override
 	Cipher cipherForEncryption() throws NoSuchAlgorithmException, NoSuchPaddingException, CertificateException, UnrecoverableKeyException, KeyStoreException, NoSuchProviderException, InvalidAlgorithmParameterException, IOException, InvalidKeyException {

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesCipherProvider.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesCipherProvider.java
@@ -19,7 +19,6 @@ package com.mtramin.rxfingerprint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
-import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -43,32 +42,32 @@ class AesCipherProvider extends CipherProvider {
 	private static final int AES_KEY_SIZE = 256;
 
 	AesCipherProvider(@NonNull Context context, @Nullable String keyName) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
-		super(context, keyName);
-	}
+        this(context, keyName, true);
+    }
+
+    AesCipherProvider(@NonNull Context context, @Nullable String keyName, boolean keyInvalidatedByBiometricEnrollment) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+        super(context, keyName, keyInvalidatedByBiometricEnrollment);
+    }
 
 	private SecretKey findOrCreateKey(String keyName) throws NoSuchProviderException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, UnrecoverableKeyException, CertificateException, KeyStoreException, IOException {
 		if (keyExists(keyName)) {
 			return getKey(keyName);
 		}
-		return createKey(keyName);
-	}
+        return createKey(keyName, invalidatedByBiometricEnrollment);
+    }
 
 	private SecretKey getKey(String keyName) throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
 		return (SecretKey) keyStore.getKey(keyName, null);
 	}
 
 	@TargetApi(Build.VERSION_CODES.M)
-	private static SecretKey createKey(String keyName) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
-		KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
-		keyGenerator.init(new KeyGenParameterSpec.Builder(keyName,
-				KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
-				.setKeySize(AES_KEY_SIZE)
-				.setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-				.setUserAuthenticationRequired(true)
-				.setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
-				.build());
-		return keyGenerator.generateKey();
-	}
+    private static SecretKey createKey(String keyName, boolean invalidatedByBiometricEnrollment) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
+        KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
+        keyGenerator.init(getKeyGenParameterSpecBuilder(keyName, KeyProperties.BLOCK_MODE_CBC, KeyProperties.ENCRYPTION_PADDING_PKCS7, invalidatedByBiometricEnrollment)
+                .setKeySize(AES_KEY_SIZE)
+                .build());
+        return keyGenerator.generateKey();
+    }
 
 	@Override
 	Cipher cipherForEncryption() throws NoSuchAlgorithmException, NoSuchPaddingException, CertificateException, UnrecoverableKeyException, KeyStoreException, NoSuchProviderException, InvalidAlgorithmParameterException, IOException, InvalidKeyException {

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesEncryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesEncryptionObservable.java
@@ -51,10 +51,10 @@ class AesEncryptionObservable extends FingerprintObservable<FingerprintEncryptio
 	 * @param keyName   name of the key in the keystore
 	 * @param toEncrypt data to encrypt  @return Observable {@link FingerprintEncryptionResult}
 	 */
-	static Observable<FingerprintEncryptionResult> create(Context context, String keyName, String toEncrypt) {
+	static Observable<FingerprintEncryptionResult> create(Context context, String keyName, String toEncrypt, boolean keyInvalidatedByBiometricEnrollment) {
 		try {
 			return Observable.create(new AesEncryptionObservable(new FingerprintApiWrapper(context),
-					new AesCipherProvider(context, keyName),
+					new AesCipherProvider(context, keyName, keyInvalidatedByBiometricEnrollment),
 					toEncrypt,
 					new Base64Provider()));
 		} catch (Exception e) {

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaCipherProvider.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaCipherProvider.java
@@ -19,7 +19,6 @@ package com.mtramin.rxfingerprint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
-import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -42,19 +41,18 @@ import javax.crypto.NoSuchPaddingException;
 
 class RsaCipherProvider extends CipherProvider {
 	RsaCipherProvider(@NonNull Context context, @Nullable String keyName) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
-		super(context, keyName);
+		this(context, keyName, true);
 	}
 
+	RsaCipherProvider(@NonNull Context context, @Nullable String keyName, boolean keyInvalidatedByBiometricEnrollment) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+		super(context, keyName, keyInvalidatedByBiometricEnrollment);
+	}
 	@Override
 	@TargetApi(Build.VERSION_CODES.M)
 	Cipher cipherForEncryption() throws GeneralSecurityException, IOException {
 		KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_RSA, ANDROID_KEY_STORE);
 
-		keyGenerator.initialize(new KeyGenParameterSpec.Builder(keyName,
-				KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
-				.setBlockModes(KeyProperties.BLOCK_MODE_ECB)
-				.setUserAuthenticationRequired(true)
-				.setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
+		keyGenerator.initialize(getKeyGenParameterSpecBuilder(keyName, KeyProperties.BLOCK_MODE_ECB, KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1, invalidatedByBiometricEnrollment)
 				.build());
 
 		keyGenerator.generateKeyPair();

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaEncryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaEncryptionObservable.java
@@ -44,13 +44,13 @@ class RsaEncryptionObservable implements ObservableOnSubscribe<FingerprintEncryp
 	 * @param keyName   name of the key in the keystore
 	 * @param toEncrypt data to encrypt  @return Observable {@link FingerprintEncryptionResult}
 	 */
-	static Observable<FingerprintEncryptionResult> create(Context context, String keyName, String toEncrypt) {
+	static Observable<FingerprintEncryptionResult> create(Context context, String keyName, String toEncrypt, boolean keyInvalidatedByBiometricEnrollment) {
 		if (toEncrypt == null) {
 			return Observable.error(new IllegalArgumentException("String to be encrypted is null. Can only encrypt valid strings"));
 		}
 		try {
 			return Observable.create(new RsaEncryptionObservable(new FingerprintApiWrapper(context),
-					new RsaCipherProvider(context, keyName),
+					new RsaCipherProvider(context, keyName, keyInvalidatedByBiometricEnrollment),
 					toEncrypt,
 					new Base64Provider()));
 		} catch (Exception e) {

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
@@ -108,7 +108,8 @@ public class RxFingerprint {
 	 *
 	 * @param context   context to use
 	 * @param toEncrypt data to encrypt
-	 * @param keyInvalidatedByBiometricEnrollment whether or not the key will be invalidated when fingerprints are added or changed.
+	 * @param keyInvalidatedByBiometricEnrollment whether or not the key will be invalidated when fingerprints are added
+	 *                                            or changed. Works only on Android N(API 24) and above.
 	 * @return Observable {@link FingerprintEncryptionResult} that will contain the encrypted data.
 	 * Will complete once the authentication and encryption were successful or have failed entirely.
 	 */
@@ -233,7 +234,8 @@ public class RxFingerprint {
 	 * @param context   context to use
 	 * @param keyName   name of the key to store in the Android {@link java.security.KeyStore}
 	 * @param toEncrypt data to encrypt
-	 * @param keyInvalidatedByBiometricEnrollment whether or not the key will be invalidated when fingerprints are added or changed.
+	 * @param keyInvalidatedByBiometricEnrollment whether or not the key will be invalidated when fingerprints are added
+	 *                                            or changed. Works only on Android N(API 24) and above.
 	 * @return Observable {@link FingerprintEncryptionResult} that will contain the encrypted data.
 	 * Will complete once the operation was successful or failed entirely.
 	 */


### PR DESCRIPTION
By default, the key is invalidated when a new fingerprint is enrolled. This can be a major annoyance for the users. Adding an option in the API to not invalidate the key on new fingerprint enrollment. 