### PR TITLE
IllegalBlockSizeException, KeyPermanentlyInvalidatedException not thrown

### DIFF
--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesDecryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesDecryptionObservable.java
@@ -98,7 +98,7 @@ class AesDecryptionObservable extends FingerprintObservable<FingerprintDecryptio
 			emitter.onNext(new FingerprintDecryptionResult(FingerprintResult.AUTHENTICATED, null, decrypted));
 			emitter.onComplete();
 		} catch (Exception e) {
-			emitter.onError(e);
+			emitter.onError(cipherProvider.mapCipherFinalOperationException(e));
 		}
 
 	}

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesEncryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesEncryptionObservable.java
@@ -101,7 +101,7 @@ class AesEncryptionObservable extends FingerprintObservable<FingerprintEncryptio
 			emitter.onNext(new FingerprintEncryptionResult(FingerprintResult.AUTHENTICATED, null, encryptedString));
 			emitter.onComplete();
 		} catch (Exception e) {
-			emitter.onError(e);
+			emitter.onError(cipherProvider.mapCipherFinalOperationException(e));
 		}
 	}
 

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/CipherProvider.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/CipherProvider.java
@@ -94,7 +94,7 @@ abstract class CipherProvider {
 	@TargetApi(Build.VERSION_CODES.M)
 	Exception mapCipherFinalOperationException(Exception e) {
 		boolean shouldThrowKeyPermanentlyInvalidatedException = invalidatedByBiometricEnrollment &&
-				Build.VERSION.SDK_INT >= 26 /*Build.VERSION_CODES.O*/ &&
+				Build.VERSION.SDK_INT == 26 /*Build.VERSION_CODES.O*/ &&
 				e instanceof IllegalBlockSizeException;
 		if (shouldThrowKeyPermanentlyInvalidatedException) {
 			Logger.warn("Removing invalidated key.");

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaDecryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaDecryptionObservable.java
@@ -92,7 +92,7 @@ class RsaDecryptionObservable extends FingerprintObservable<FingerprintDecryptio
 			emitter.onComplete();
 		} catch (Exception e) {
 			Logger.error("Unable to decrypt given value. RxFingerprint is only able to decrypt values previously encrypted by RxFingerprint with the same encryption mode.", e);
-			emitter.onError(e);
+			emitter.onError(cipherProvider.mapCipherFinalOperationException(e));
 		}
 
 	}


### PR DESCRIPTION
Fixed IllegalBlockSizeException on some devices (KeyPermanentlyInvalidatedException not thrown all the time after enrolling new fingerprint).

See:
- https://issuetracker.google.com/issues/65578763
- https://github.com/googlesamples/android-FingerprintDialog/issues/21