### PR TITLE
Changes to use char[] for cleartext instead of String

### DIFF
--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesDecryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/AesDecryptionObservable.java
@@ -93,9 +93,9 @@ class AesDecryptionObservable extends FingerprintObservable<FingerprintDecryptio
 		try {
 			CryptoData cryptoData = CryptoData.fromString(encodingProvider, encryptedString);
 			Cipher cipher = result.getCryptoObject().getCipher();
-			String decrypted = new String(cipher.doFinal(cryptoData.getMessage()));
+			byte[] bytes = cipher.doFinal(cryptoData.getMessage());
 
-			emitter.onNext(new FingerprintDecryptionResult(FingerprintResult.AUTHENTICATED, null, decrypted));
+			emitter.onNext(new FingerprintDecryptionResult(FingerprintResult.AUTHENTICATED, null, ConversionUtils.toChars(bytes)));
 			emitter.onComplete();
 		} catch (Exception e) {
 			emitter.onError(cipherProvider.mapCipherFinalOperationException(e));

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/ConversionUtils.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/ConversionUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Marvin Ramin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mtramin.rxfingerprint;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+/**
+ * Data conversion utility methods
+ */
+class ConversionUtils {
+
+  // based on https://stackoverflow.com/a/9670279/115145
+
+  static byte[] toBytes(char[] chars) {
+    CharBuffer charBuffer = CharBuffer.wrap(chars);
+    ByteBuffer byteBuffer = Charset.forName("UTF-8").encode(charBuffer);
+    byte[] bytes = Arrays.copyOfRange(byteBuffer.array(), byteBuffer.position(), byteBuffer.limit());
+
+    Arrays.fill(charBuffer.array(), '\u0000'); // clear the cleartext
+    Arrays.fill(byteBuffer.array(), (byte) 0); // clear the ciphertext
+
+    return bytes;
+  }
+
+  static char[] toChars(byte[] bytes) {
+    Charset charset = Charset.forName("UTF-8");
+    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+    CharBuffer charBuffer = charset.decode(byteBuffer);
+    char[] chars = Arrays.copyOf(charBuffer.array(), charBuffer.limit());
+
+    Arrays.fill(charBuffer.array(), '\u0000'); // clear the cleartext
+    Arrays.fill(byteBuffer.array(), (byte) 0); // clear the ciphertext
+
+    return chars;
+  }
+}

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaDecryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaDecryptionObservable.java
@@ -86,9 +86,8 @@ class RsaDecryptionObservable extends FingerprintObservable<FingerprintDecryptio
 		try {
 			Cipher cipher = result.getCryptoObject().getCipher();
 			byte[] bytes = cipher.doFinal(encodingProvider.decode(encryptedString));
-			String decrypted = new String(bytes, "UTF-8");
 
-			emitter.onNext(new FingerprintDecryptionResult(FingerprintResult.AUTHENTICATED, null, decrypted));
+			emitter.onNext(new FingerprintDecryptionResult(FingerprintResult.AUTHENTICATED, null, ConversionUtils.toChars(bytes)));
 			emitter.onComplete();
 		} catch (Exception e) {
 			Logger.error("Unable to decrypt given value. RxFingerprint is only able to decrypt values previously encrypted by RxFingerprint with the same encryption mode.", e);

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaEncryptionObservable.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RsaEncryptionObservable.java
@@ -33,7 +33,7 @@ class RsaEncryptionObservable implements ObservableOnSubscribe<FingerprintEncryp
 
 	private final FingerprintApiWrapper fingerprintApiWrapper;
 	private final RsaCipherProvider cipherProvider;
-	private final String toEncrypt;
+	private final char[] toEncrypt;
 	private final EncodingProvider encodingProvider;
 
 	/**
@@ -44,7 +44,7 @@ class RsaEncryptionObservable implements ObservableOnSubscribe<FingerprintEncryp
 	 * @param keyName   name of the key in the keystore
 	 * @param toEncrypt data to encrypt  @return Observable {@link FingerprintEncryptionResult}
 	 */
-	static Observable<FingerprintEncryptionResult> create(Context context, String keyName, String toEncrypt, boolean keyInvalidatedByBiometricEnrollment) {
+	static Observable<FingerprintEncryptionResult> create(Context context, String keyName, char[] toEncrypt, boolean keyInvalidatedByBiometricEnrollment) {
 		if (toEncrypt == null) {
 			return Observable.error(new IllegalArgumentException("String to be encrypted is null. Can only encrypt valid strings"));
 		}
@@ -61,7 +61,7 @@ class RsaEncryptionObservable implements ObservableOnSubscribe<FingerprintEncryp
 	@VisibleForTesting
 	RsaEncryptionObservable(FingerprintApiWrapper fingerprintApiWrapper,
 							RsaCipherProvider cipherProvider,
-							String toEncrypt,
+							char[] toEncrypt,
 							EncodingProvider encodingProvider) {
 		this.fingerprintApiWrapper = fingerprintApiWrapper;
 		this.cipherProvider = cipherProvider;
@@ -78,7 +78,7 @@ class RsaEncryptionObservable implements ObservableOnSubscribe<FingerprintEncryp
 
 		try {
 			Cipher cipher = cipherProvider.getCipherForEncryption();
-			byte[] encryptedBytes = cipher.doFinal(toEncrypt.getBytes("UTF-8"));
+			byte[] encryptedBytes = cipher.doFinal(ConversionUtils.toBytes(toEncrypt));
 
 			String encryptedString = encodingProvider.encode(encryptedBytes);
 			emitter.onNext(new FingerprintEncryptionResult(FingerprintResult.AUTHENTICATED, null, encryptedString));

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/RxFingerprint.java
@@ -117,6 +117,35 @@ public class RxFingerprint {
 		return encrypt(EncryptionMethod.AES, context, null, toEncrypt, keyInvalidatedByBiometricEnrollment);
 	}
 
+	/**
+	 * Encrypt data and authenticate the user with his fingerprint. The encrypted data can only be
+	 * accessed again by calling {@link #decrypt(Context, String)}. Will use a default keyName in
+	 * the Android keystore unique to this applications package name.
+	 * If you want to provide a custom key name use {@link #encrypt(Context, String, String)}
+	 * instead.
+	 * <p/>
+	 * Encrypted data is only accessible after the user has authenticated with
+	 * fingerprint authentication.
+	 * <p/>
+	 * Encryption uses AES encryption with CBC blocksize and PKCS7 padding.
+	 * The key-length for AES encryption is set to 265 bits by default.
+	 * <p/>
+	 * The resulting {@link FingerprintEncryptionResult} will contain the encrypted data as a String
+	 * and is accessible via {@link FingerprintEncryptionResult#getEncrypted()} if the
+	 * authentication was successful. Save this data where you please, but don't change it if you
+	 * want to decrypt it again!
+	 *
+	 * @param context   context to use
+	 * @param toEncrypt data to encrypt
+	 * @param keyInvalidatedByBiometricEnrollment whether or not the key will be invalidated when fingerprints are added
+	 *                                            or changed. Works only on Android N(API 24) and above.
+	 * @return Observable {@link FingerprintEncryptionResult} that will contain the encrypted data.
+	 * Will complete once the authentication and encryption were successful or have failed entirely.
+	 */
+	public static Observable<FingerprintEncryptionResult> encrypt(@NonNull Context context, @NonNull char[] toEncrypt, boolean keyInvalidatedByBiometricEnrollment) {
+		return encrypt(EncryptionMethod.AES, context, null, toEncrypt, keyInvalidatedByBiometricEnrollment);
+	}
+
     /**
      * Decrypt data previously encrypted with {@link #encrypt(Context, String)}.
      * <p/>
@@ -163,6 +192,30 @@ public class RxFingerprint {
     public static Observable<FingerprintEncryptionResult> encrypt(@NonNull Context context, @Nullable String keyName, @NonNull String toEncrypt) {
         return encrypt(EncryptionMethod.AES, context, keyName, toEncrypt, true);
     }
+
+	/**
+	 * Encrypt data  and authenticate the user with his fingerprint. The encrypted data can only be
+	 * accessed again by calling {@link #decrypt(Context, String, String)} with the same keyName.
+	 * Encrypted data is only accessible after the user has authenticated with
+	 * fingerprint authentication.
+	 * <p/>
+	 * Encryption uses AES encryption with CBC blocksize and PKCS7 padding.
+	 * The key-length for AES encryption is set to 265 bits by default.
+	 * <p/>
+	 * The resulting {@link FingerprintEncryptionResult} will contain the encrypted data as a String
+	 * and is accessible via {@link FingerprintEncryptionResult#getEncrypted()} if the
+	 * authentication was successful. Save this data where you please, but don't change it if you
+	 * want to decrypt it again!
+	 *
+	 * @param context   context to use
+	 * @param keyName   name of the key in the keystore to use
+	 * @param toEncrypt data to encrypt
+	 * @return Observable {@link FingerprintEncryptionResult} that will contain the encrypted data.
+	 * Will complete once the authentication and encryption were successful or have failed entirely.
+	 */
+	public static Observable<FingerprintEncryptionResult> encrypt(@NonNull Context context, @Nullable String keyName, @NonNull char[] toEncrypt) {
+		return encrypt(EncryptionMethod.AES, context, keyName, toEncrypt, true);
+	}
 
     /**
      * Decrypt data previously encrypted with {@link #encrypt(Context, String, String)}.
@@ -215,6 +268,33 @@ public class RxFingerprint {
 																  @NonNull String toEncrypt) {
 		return encrypt(method, context, keyName, toEncrypt, true);
 	}
+	/**
+	 * Encrypt data with the given {@link EncryptionMethod}. Depending on the given method, the
+	 * fingerprint sensor might be enabled and waiting for the user to authenticate before the
+	 * encryption step. All encrypted data can only be accessed again by calling
+	 * {@link #decrypt(EncryptionMethod, Context, String, String)} with the same
+	 * {@link EncryptionMethod} that was used for encryption of the given value.
+	 * <p>
+	 * Take more details about the encryption method and how they behave from {@link EncryptionMethod}
+	 * <p>
+	 * The resulting {@link FingerprintEncryptionResult} will contain the encrypted data as a String
+	 * and is accessible via {@link FingerprintEncryptionResult#getEncrypted()} if the
+	 * operation was successful. Save this data where you please, but don't change it if you
+	 * want to decrypt it again!
+	 *
+	 * @param method    the encryption method to use
+	 * @param context   context to use
+	 * @param keyName   name of the key to store in the Android {@link java.security.KeyStore}
+	 * @param toEncrypt data to encrypt
+	 * @return Observable {@link FingerprintEncryptionResult} that will contain the encrypted data.
+	 * Will complete once the operation was successful or failed entirely.
+	 */
+	public static Observable<FingerprintEncryptionResult> encrypt(@NonNull EncryptionMethod method,
+																																@NonNull Context context,
+																																@Nullable String keyName,
+																																@NonNull char[] toEncrypt) {
+		return encrypt(method, context, keyName, toEncrypt, true);
+	}
 
 	/**
 	 * Encrypt data with the given {@link EncryptionMethod}. Depending on the given method, the
@@ -244,6 +324,37 @@ public class RxFingerprint {
 																  @Nullable String keyName,
 																  @NonNull String toEncrypt,
 																  boolean keyInvalidatedByBiometricEnrollment) {
+		return encrypt(method, context, keyName, toEncrypt.toCharArray(), keyInvalidatedByBiometricEnrollment);
+	}
+
+	/**
+	 * Encrypt data with the given {@link EncryptionMethod}. Depending on the given method, the
+	 * fingerprint sensor might be enabled and waiting for the user to authenticate before the
+	 * encryption step. All encrypted data can only be accessed again by calling
+	 * {@link #decrypt(EncryptionMethod, Context, String, String)} with the same
+	 * {@link EncryptionMethod} that was used for encryption of the given value.
+	 * <p>
+	 * Take more details about the encryption method and how they behave from {@link EncryptionMethod}
+	 * <p>
+	 * The resulting {@link FingerprintEncryptionResult} will contain the encrypted data as a String
+	 * and is accessible via {@link FingerprintEncryptionResult#getEncrypted()} if the
+	 * operation was successful. Save this data where you please, but don't change it if you
+	 * want to decrypt it again!
+	 *
+	 * @param method    the encryption method to use
+	 * @param context   context to use
+	 * @param keyName   name of the key to store in the Android {@link java.security.KeyStore}
+	 * @param toEncrypt data to encrypt
+	 * @param keyInvalidatedByBiometricEnrollment whether or not the key will be invalidated when fingerprints are added
+	 *                                            or changed. Works only on Android N(API 24) and above.
+	 * @return Observable {@link FingerprintEncryptionResult} that will contain the encrypted data.
+	 * Will complete once the operation was successful or failed entirely.
+	 */
+	public static Observable<FingerprintEncryptionResult> encrypt(@NonNull EncryptionMethod method,
+																																@NonNull Context context,
+																																@Nullable String keyName,
+																																@NonNull char[] toEncrypt,
+																																boolean keyInvalidatedByBiometricEnrollment) {
 		switch (method) {
 			case AES:
 				return AesEncryptionObservable.create(context, keyName, toEncrypt, keyInvalidatedByBiometricEnrollment);

--- a/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/data/FingerprintDecryptionResult.java
+++ b/rxfingerprint/src/main/java/com/mtramin/rxfingerprint/data/FingerprintDecryptionResult.java
@@ -22,7 +22,7 @@ package com.mtramin.rxfingerprint.data;
  */
 public class FingerprintDecryptionResult extends FingerprintAuthenticationResult {
 
-    private final String decrypted;
+    private final char[] decrypted;
 
     /**
      * Default constructor
@@ -31,7 +31,7 @@ public class FingerprintDecryptionResult extends FingerprintAuthenticationResult
      * @param message   message to be displayed to the user
      * @param decrypted decrypted data
      */
-    public FingerprintDecryptionResult(FingerprintResult result, String message, String decrypted) {
+    public FingerprintDecryptionResult(FingerprintResult result, String message, char[] decrypted) {
         super(result, message);
         this.decrypted = decrypted;
     }
@@ -41,6 +41,14 @@ public class FingerprintDecryptionResult extends FingerprintAuthenticationResult
      * authentication was of type {@link FingerprintResult#AUTHENTICATED}.
      */
     public String getDecrypted() {
+        return new String(getDecryptedChars());
+    }
+
+    /**
+     * @return decrypted data as a char[]. Can only be accessed if the result of the fingerprint
+     * authentication was of type {@link FingerprintResult#AUTHENTICATED}.
+     */
+    public char[] getDecryptedChars() {
         if (!isSuccess()) {
             throw new IllegalAccessError("Fingerprint authentication was not successful, cannot access decryption result");
         }

--- a/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/RsaEncryptionObservableTest.java
+++ b/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/RsaEncryptionObservableTest.java
@@ -53,7 +53,7 @@ public class RsaEncryptionObservableTest {
 		cipher = mock(Cipher.class);
 		RxFingerprint.disableLogging();
 
-		observable = Observable.create(new RsaEncryptionObservable(fingerprintApiWrapper, cipherProvider, INPUT, new TestEncodingProvider()));
+		observable = Observable.create(new RsaEncryptionObservable(fingerprintApiWrapper, cipherProvider, INPUT.toCharArray(), new TestEncodingProvider()));
 	}
 
 	@Test
@@ -79,7 +79,7 @@ public class RsaEncryptionObservableTest {
 	public void encrypt() throws Exception {
 		when(fingerprintApiWrapper.isUnavailable()).thenReturn(false);
 		when(cipherProvider.getCipherForEncryption()).thenReturn(cipher);
-		when(cipher.doFinal(INPUT.getBytes("UTF-8"))).thenReturn(INPUT.getBytes("UTF-8"));
+		when(cipher.doFinal(ConversionUtils.toBytes(INPUT.toCharArray()))).thenReturn(ConversionUtils.toBytes(INPUT.toCharArray()));
 
 		FingerprintEncryptionResult fingerprintEncryptionResult = observable.test()
 				.assertValueCount(1)

--- a/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/data/FingerprintDecryptionResultTest.java
+++ b/rxfingerprint/src/test/java/com/mtramin/rxfingerprint/data/FingerprintDecryptionResultTest.java
@@ -9,11 +9,11 @@ public class FingerprintDecryptionResultTest {
 
 	@Test
 	public void getResultSuccess() throws Exception {
-		String decrypted = "decrypted";
+		char[] decrypted = "decrypted".toCharArray();
 		FingerprintDecryptionResult result = new FingerprintDecryptionResult(FingerprintResult.AUTHENTICATED, null, decrypted);
 
 		assertNull(result.getMessage());
-		assertEquals(decrypted, result.getDecrypted());
+		assertEquals(decrypted, result.getDecryptedChars());
 	}
 
 	@Test(expected = IllegalAccessError.class)


### PR DESCRIPTION
This addresses issue #82.

The approach that I took was to have the observables and `FingerprintDecryptionResult` work purely with `char[]`, with the `String` option limited to the `RxFingerprint` `encrypt()` methods. I updated the corresponding unit tests, which pass.

I needed two utility methods for converting between `char[]` and `byte[]`. Since I didn't see another likely home for them, I created a `ConversionUtils` class and put them there.

Let me know how you would like to proceed -- thanks!
